### PR TITLE
Update OpenClonk repository URL

### DIFF
--- a/games.yaml
+++ b/games.yaml
@@ -78,7 +78,7 @@
   clones:
     - name: OpenClonk
       url: http://www.openclonk.org/
-      repo: http://hg.openclonk.org/openclonk/
+      repo: http://git.openclonk.org/openclonk.git/
       info: active development, C++
       added: 2012-04-07
       media:


### PR DESCRIPTION
They switched to git recently.
