### PR TITLE
fix info of arx fatalis

### DIFF
--- a/games.yaml
+++ b/games.yaml
@@ -24,7 +24,7 @@
       url: http://arx-libertatis.org/
       repo: https://github.com/arx/ArxLibertatis
       added: 2013-05-27
-      info: active development, C++; needs original game files (OpenMW)
+      info: active development, C++; needs original game files
       media:
         - raw: <iframe width="560" height="315" src="http://www.youtube.com/embed/mIribIqKee8?rel=0" frameborder="0" allowfullscreen></iframe>
         - image: http://wiki.arx-libertatis.org/images/thumb/e/e1/Castle.jpg/120px-Castle.jpg


### PR DESCRIPTION
OpenMW was only meant as another example of an engine that needs original data files, it is not related to arx libertatis in any way
