### PR TITLE
Added yet another Dune II clone and a dead Starcraft for iPad project

### DIFF
--- a/games.yaml
+++ b/games.yaml
@@ -880,6 +880,11 @@
       repo: https://code.launchpad.net/stargus
       info: moderately active development, C++/Lua
       added: 2013-06-08
+    - url: https://github.com/toshok/scsharp/wiki
+      name: SCSharp
+      repo: https://github.com/toshok/scsharp
+      info: development halted, C#
+      added: 2013-06-09
 
 
 - name: [Stunts, Stunts (video game)]


### PR DESCRIPTION
Dune Dynasty seems to be a fork of OpenDUNE because the mother project is very conservative.

I can't even compile SCSharp as I don't have MonoMac nor the hardware. According to the YouTube videos it is in very early stages and far from playable.
