### PR TITLE
Change Cyberdogs to C-Dogs

### DIFF
--- a/games.yaml
+++ b/games.yaml
@@ -252,7 +252,7 @@
         - image: http://coab.googlecode.com/svn/pics/title-screen.png
         - image: http://coab.googlecode.com/svn/pics/world-map.png
 
-- name: Cyberdogs
+- name: C-Dogs
   clones:
     - name: C-Dogs SDL
       url: http://cxong.github.io/cdogs-sdl/


### PR DESCRIPTION
C-Dogs SDL is an evolution of C-Dogs, not Cyberdogs.
Also Cyberdogs has no wikipedia page
