### PR TITLE
[fix] Correct glportal url.

### DIFF
--- a/games.yaml
+++ b/games.yaml
@@ -814,8 +814,8 @@
 - name: [Portal, Portal (video game)]
   clones:
     - name: glPortal
-      url: http://social.w3-net.de/glportal
-      repo: https://github.com/hhirsch/glPortal
+      url: http://glportal.de/glportal
+      repo: https://github.com/GlPortal/glPortal
       info: somewhat active development, C++, playable
       added: 2013-06-25
       media:


### PR DESCRIPTION
As requested by mail here is the proper URL for glportal.
