### PR TITLE
Updated ioquake3's repo

### DIFF
--- a/yearofthelinuxdesktopbot.py
+++ b/yearofthelinuxdesktopbot.py
@@ -862,7 +862,7 @@
   clones:
     - name: ioquake3
       url: http://ioquake3.org/
-      repo: http://svn.icculus.org/quake3/trunk/
+      repo: https://github.com/ioquake/ioq3
       info: active development, C
       media:
         - image: http://ioquake3.org/images/screenshots/arenalinux.jpeg


### PR DESCRIPTION
ioquake3 moved to github a long time ago. This file had the old SVN address.
