### PR TITLE
Expand Jumpgate name to "Jumpgate: The Reconstruction Initiative"

### DIFF
--- a/games.yaml
+++ b/games.yaml
@@ -852,7 +852,7 @@
       info: active development, playable, C++
 
 
-- name: Jumpgate: The Reconstruction Initiative
+- name: "Jumpgate: The Reconstruction Initiative"
   clones:
     - name: Open Jumpgate
       url: http://sourceforge.net/projects/opengate/


### PR DESCRIPTION
"Jumpgate" doesn't lead to the game
