### PR TITLE
Resolve OpenTTD repository change (and minor cleanup)

### DIFF
--- a/games/o.yaml
+++ b/games/o.yaml
@@ -758,7 +758,8 @@
   status: playable
   development: active
   lang: C++
-  repo: http://vcs.openttd.org/svn/timeline
+  repo: https://github.com/OpenTTD/OpenTTD
+  updated: 2018-05-03
   license: [GPL2]
   content: swappable
   images: ['https://media.openttd.org/images/screens/1.4/02-opengfx-1920x1200.png',

--- a/games/o.yaml
+++ b/games/o.yaml
@@ -753,8 +753,9 @@
   development: active
   lang: Java
   remakes: [Final Fantasy VIII]
-- url: http://www.openttd.org/
-  name: OpenTTD
+
+- name: OpenTTD
+  url: http://www.openttd.org/
   status: playable
   development: active
   lang: C++
@@ -765,6 +766,7 @@
   images: ['https://media.openttd.org/images/screens/1.4/02-opengfx-1920x1200.png',
     'https://media.openttd.org/images/screens/1.3/realgrowth.png']
   remakes: [Transport Tycoon]
+
 - url: https://bitbucket.org/opentyrian/opentyrian/wiki/Home
   name: OpenTyrian
   development: sporadic


### PR DESCRIPTION
This PR has two commits. The first fixes issue #555 in which OpenTTD moved their central repository to GitHub. :tada: The second commit cleans up the surrounding metadata.