### PR TITLE
FreeRCT stopped in 2016 (update to halted)

### DIFF
--- a/games/f.yaml
+++ b/games/f.yaml
@@ -351,9 +351,9 @@
 - name: FreeRCT
   url: http://freerct.org/
   repo: http://github.com/FreeRCT/FreeRCT
-  development: active
+  development: halted
   lang: C++
-  updated: 2013-07-05
+  updated: 2018-05-03
   remakes: [RollerCoaster Tycoon]
 
 - name: Freeserf


### PR DESCRIPTION
This was probably due to OpenRCT2 becoming more popular.