### PR TITLE
Fix SunDog: Frozen Legacy

### DIFF
--- a/originals/s.yaml
+++ b/originals/s.yaml
@@ -168,7 +168,9 @@
     genre: [Arcade]
 
 - name: 'SunDog: Frozen Legacy'
-  meta: {genre: Role Playing}
+  meta:
+    genre: [RPG]
+    subgenre: [Space Flight]
 
 - name: Supaplex
   meta:


### PR DESCRIPTION
SunDog is the only game of the bunch that is marked as `Role Playing` when others use `RPG`. And on Wikipedia, it's described as a "space trading and combat simulator", so I've added the closest thing that can be listed, the `Space Flight` subgenre.

If these are incorrect, go ahead and close this PR.