### PR TITLE
Add check for duplicate original games

### DIFF
--- a/_ext.py
+++ b/_ext.py
@@ -232,17 +232,23 @@ def parse_data(site):
         else:
             raise error
 
-
-    originals_map = {}
-    for item in originals:
-        for name in names(item):
-            if type(name) not in [list, tuple]:
-                name = [name]
-
-            for subname in name:
-                originals_map[subname] = item
-
     errors = []
+    originals_map = {}
+
+    for item in originals:
+        name = game_name(item)
+
+        if name in originals_map:
+            errors.append({
+                "name": name,
+                "error": "Duplicate original game '%s'" % name
+            })
+
+        originals_map[name] = item
+
+    if len(errors) > 0:
+        show_errors(errors)
+
     for clone in clones:
         clone_originals = []
 

--- a/games/p.yaml
+++ b/games/p.yaml
@@ -110,7 +110,7 @@
   lang: C++
   updated: 2014-09-19
   video: {youtube: soYIbsVmcyU}
-  clones: [Guitar Hero]
+  clones: [Guitar Hero, SingStar, Dance Dance Revolution]
 
 - name: Phantasy
   updated: 2015-05-28

--- a/games/s.yaml
+++ b/games/s.yaml
@@ -475,7 +475,7 @@
   development: active
   lang: [C++, Lua]
   updated: 2014-12-21
-  clones: [Guitar Hero]
+  clones: [Dance Dance Revolution]
 
 - name: Stunt Car Racer Remake
   url: http://sourceforge.net/projects/stuntcarremake/

--- a/originals/d.yaml
+++ b/originals/d.yaml
@@ -4,6 +4,10 @@
   meta:
     genre: [RPG]
 
+- name: Dance Dance Revolution
+  meta:
+    genre: [Rhythm]
+
 - name: [Dandy, Dandy (video game)]
   meta:
     genre: [Arcade]

--- a/originals/g.yaml
+++ b/originals/g.yaml
@@ -64,8 +64,3 @@
 - name: Guitar Hero
   meta:
     genre: [Rhythm]
-
-- name: Guitar Hero
-  names: [SingStar, Dance Dance Revolution]
-  meta:
-    genre: [Rhythm]

--- a/originals/m.yaml
+++ b/originals/m.yaml
@@ -153,10 +153,6 @@
   meta:
     genre: [Simulation]
 
-- name: Missile Command
-  meta:
-    genre: [Arcade]
-
 - name: Midnight Club II
   names: [Midnight Club 2]
   meta:


### PR DESCRIPTION
As I mentioned in #587, duplicate games cause problems when sorting by tags. ~~Although this doesn't fix the issue entirely, it does solve a problem anyways.~~ It appears to fix it entirely!

Guitar Hero was one of the culprits of duplication, but the second entry contained "alternate names", SingStar and DDR. After looking into it, it seems that it was for Performous, since it claims to be a clone of all 3, so I simply added the extra games in the `clones` list for Performous instead.