### PR TITLE
Remove Rigs of Rods

### DIFF
--- a/games/r.yaml
+++ b/games/r.yaml
@@ -240,31 +240,6 @@
   updated: 2015-04-03
   url: http://sourceforge.net/projects/rickyd/
 
-- name: Rigs of Rods
-  framework:
-  - OGRE3D Engine
-  images:
-  - http://rigsofrods.org/images/screenshots/ror-screenshot5.jpg
-  - http://rigsofrods.org/images/screenshots/ror-screenshot6.jpg
-  - http://rigsofrods.org/images/screenshots/ror-screenshot7.jpg
-  lang:
-  - C
-  - C++
-  - AngelScript
-  - Python
-  license:
-  - GPL3
-  development: active
-  originals:
-  - BeamNG.drive
-  repo: https://github.com/RigsOfRods/rigs-of-rods
-  status: playable
-  type: clone
-  updated: 2016-11-30
-  url: http://rigsofrods.org/
-  video:
-    youtube: bRbQ4OaljWs
-
 - name: Rise of the Triad for Linux
   lang: C
   development: sporadic


### PR DESCRIPTION
Rigs of Rods is a not a clone of BeamNG. Did the person who add this bother to lookup the history between these two games? Rigs of Rods was released in 2005. BeamNG was officially launched in 2015 by former developers of Rigs of Rods.