### PR TITLE
Split links into metadata for original games

### DIFF
--- a/_ext.py
+++ b/_ext.py
@@ -158,6 +158,7 @@ def parse_items(site, item, key):
 
         meta = item.get('meta', {})
         meta["names_ascii"] = parse_unicode(names(item))
+        meta["external"] = item.get('external', {})
 
         parse_fn = partial(parse_item, entry_tags=game_tags, meta=meta, meta_tags=meta_tags)
 

--- a/originals/0scumm.yaml
+++ b/originals/0scumm.yaml
@@ -1,9 +1,16 @@
-
 - name: SCUMM
+  external:
+    wikipedia: SCUMM
   meta:
-    genre: [Adventure, Compilation]
+    genre:
+    - Adventure
+    - Compilation
 
 - name: 3D Deathchase
+  external:
+    wikipedia: 3D Deathchase
   meta:
-    genre: [Racing]
-    subgenre: [Vehicular Combat]
+    genre:
+    - Racing
+    subgenre:
+    - Vehicular Combat

--- a/originals/a.yaml
+++ b/originals/a.yaml
@@ -1,174 +1,323 @@
-
-- name: [Abuse, Abuse (video game)]
+- name: A-Train
+  external:
+    wikipedia: A-Train
   meta:
-    genre: [Action, Platform]
-    theme: [Horror, Sci-Fi]
+    genre:
+    - Simulation
 
-- name: [Ace of Spades, Ace of Spades (video game)]
+- name: Abuse
+  external:
+    wikipedia: Abuse (video game)
   meta:
-    genre: [FPS]
-    theme: [World War II]
+    genre:
+    - Action
+    - Platform
+    theme:
+    - Horror
+    - Sci-Fi
 
 - name: 'Ace Combat: Assault Horizon'
+  external:
+    wikipedia: 'Ace Combat: Assault Horizon'
   meta:
-    genre: [Action, Simulation]
-    subgenre: [Flight Simulator]
-    theme: [Modern Military]
+    genre:
+    - Action
+    - Simulation
+    subgenre:
+    - Flight Simulator
+    theme:
+    - Modern Military
 
-- name: Advance Wars
+- name: Ace of Spades
+  external:
+    wikipedia: Ace of Spades (video game)
   meta:
-    genre: [TBS]
+    genre:
+    - FPS
+    theme:
+    - World War II
 
 - name: Achtung, die Kurve!
-  names: [Curve Fever, Zatacka]
+  external:
+    wikipedia: Achtung, die Kurve!
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
+  names:
+  - Curve Fever
+  - Zatacka
+
+- name: Advance Wars
+  external:
+    wikipedia: Advance Wars
+  meta:
+    genre:
+    - TBS
 
 - name: Age of Empires
+  external:
+    wikipedia: Age of Empires
   meta:
-    genre: [RTS]
+    genre:
+    - RTS
     subgenre: []
     theme: []
 
 - name: Age of Empires II
+  external:
+    wikipedia: Age of Empires II
   meta:
-    genre: [RTS]
+    genre:
+    - RTS
     subgenre: []
-    theme: [Medieval]
+    theme:
+    - Medieval
 
 - name: 'Akalabeth: World of Doom'
+  external:
+    wikipedia: 'Akalabeth: World of Doom'
   meta:
-    genre: [RPG]
-    theme: [Fantasy]
+    genre:
+    - RPG
+    theme:
+    - Fantasy
 
 - name: Alien 8
+  external:
+    wikipedia: Alien 8
   meta:
-    genre: [Action]
+    genre:
+    - Action
 
-- name: [Allegiance, Allegiance (video game)]
+- name: Allegiance
+  external:
+    wikipedia: Allegiance (video game)
   meta:
-    genre: [Action, Simulation, RTS]
-    theme: [Sci-Fi]
+    genre:
+    - Action
+    - Simulation
+    - RTS
+    theme:
+    - Sci-Fi
 
 - name: Alone in the Dark
+  external:
+    wikipedia: Alone in the Dark
   meta:
-    genre: [Action, Adventure]
-    theme: [Horror, Alternate Historical]
+    genre:
+    - Action
+    - Adventure
+    theme:
+    - Horror
+    - Alternate Historical
 
 - name: Alone in the Dark 2
+  external:
+    wikipedia: Alone in the Dark 2
   meta:
-    genre: [Action, Adventure]
-    theme: [Horror, Alternate Historical]
+    genre:
+    - Action
+    - Adventure
+    theme:
+    - Horror
+    - Alternate Historical
 
 - name: Alone in the Dark 3
+  external:
+    wikipedia: Alone in the Dark 3
   meta:
-    genre: [Action, Adventure]
-    theme: [Horror, Alternate Historical]
+    genre:
+    - Action
+    - Adventure
+    theme:
+    - Horror
+    - Alternate Historical
 
 - name: 'Anacreon: Reconstruction 4021'
+  external:
+    wikipedia: 'Anacreon: Reconstruction 4021'
   meta:
-    genre: [TBS]
-    theme: [Sci-Fi, Management]
+    genre:
+    - TBS
+    theme:
+    - Sci-Fi
+    - Management
 
-- name: [Another World, Another World (video game)]
+- name: Anno series
+  external:
+    wikipedia: Anno_1602
+  meta:
+    genre:
+    - RTS
+
+- name: Another World
+  external:
+    wikipedia: Another World (video game)
+  meta:
+    genre:
+    - Adventure
+    - Platform
+    theme:
+    - Sci-Fi
   names:
-  - [Out of This World, Another World (video game)]
-  - ["Outer World (\u30A2\u30A6\u30BF\u30FC\u30EF\u30FC\u30EB\u30C9 Aut\u0101 W\u0101\
-      rudo)", Another World (video game)]
-  meta:
-    genre: [Adventure, Platform]
-    theme: [Sci-Fi]
+  - Out of This World
+  - "Outer World (\u30A2\u30A6\u30BF\u30FC\u30EF\u30FC\u30EB\u30C9 Aut\u0101 W\u0101\
+    rudo)"
 
-- name: ['Another World 2: Heart of the Alien', Heart of the Alien]
+- name: 'Another World 2: Heart of the Alien'
+  external:
+    wikipedia: Heart of the Alien
   meta:
-    genre: [Adventure, Platform]
+    genre:
+    - Adventure
+    - Platform
 
 - name: AquaStax
-  platform: [Mobile]
+  external:
+    wikipedia: AquaStax
   meta:
-    genre: [Puzzle, Platform]
+    genre:
+    - Puzzle
+    - Platform
+  platform:
+  - Mobile
 
 - name: 'Archon: The Light and the Dark'
+  external:
+    wikipedia: 'Archon: The Light and the Dark'
   meta:
-    genre: [TBS]
+    genre:
+    - TBS
 
-- name: [Ares, Ares (video game)]
+- name: Ares
+  external:
+    wikipedia: Ares (video game)
   meta:
-    genre: [Arcade, RTS]
-
-- name: 'ARMA: Armed Assault'
-  meta:
-    genre: [FPS]
-    theme: [Modern Military]
-
-- name: ARMA 2
-  meta:
-    genre: [FPS]
-    theme: [Modern Military]
-
-- name: ARMA 3
-  meta:
-    genre: [FPS]
-    theme: [Modern Military]
-
-- name: Armor Alley
-  meta:
-    genre: [Arcade, Real-Time Tactics]
-    theme: [Modern Military]
-
-- name: 'Artemis: Spaceship Bridge Simulator'
-  meta:
-    genre: [Simulation]
-    theme: [Sci-Fi]
-
-- name: Artillery Duel
-  meta:
-    genre: [Artillery]
-
-- name: Arx Fatalis
-  meta:
-    genre: [RPG]
-
-- name: Ascendancy
-  meta:
-    genre: [TBS]
-
-- name: [Asteroids, Asteroids (video game)]
-  meta:
-    genre: [Arcade]
-
-- name: [Asylum, 'https://www.mobygames.com/game/acorn-32-bit/asylum']
-  meta:
-    genre: [Action]
-
-- name: [Atomix, Atomix (video game)]
-  meta:
-    genre: [Puzzle]
-
-- name: AstroMenace
-  meta:
-    genre: [Shmup]
-
-- name: Astrosmash
-  meta:
-    genre: [Arcade]
-
-- name: Atomic Bomberman
-  meta:
-    genre: [Action]
-
-- name: Awesomenauts
-  meta:
-    genre: [RPG, RTS]
-
-- name: A-Train
-  meta:
-    genre: [Simulation]
-
-- name: [Anno series, Anno_1602]
-  meta:
-    genre: [RTS]
+    genre:
+    - Arcade
+    - RTS
 
 - name: Arkanoid
+  external:
+    wikipedia: Arkanoid
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
+
+- name: ARMA 2
+  external:
+    wikipedia: ARMA 2
+  meta:
+    genre:
+    - FPS
+    theme:
+    - Modern Military
+
+- name: ARMA 3
+  external:
+    wikipedia: ARMA 3
+  meta:
+    genre:
+    - FPS
+    theme:
+    - Modern Military
+
+- name: 'ARMA: Armed Assault'
+  external:
+    wikipedia: 'ARMA: Armed Assault'
+  meta:
+    genre:
+    - FPS
+    theme:
+    - Modern Military
+
+- name: Armor Alley
+  external:
+    wikipedia: Armor Alley
+  meta:
+    genre:
+    - Arcade
+    - Real-Time Tactics
+    theme:
+    - Modern Military
+
+- name: 'Artemis: Spaceship Bridge Simulator'
+  external:
+    wikipedia: 'Artemis: Spaceship Bridge Simulator'
+  meta:
+    genre:
+    - Simulation
+    theme:
+    - Sci-Fi
+
+- name: Artillery Duel
+  external:
+    wikipedia: Artillery Duel
+  meta:
+    genre:
+    - Artillery
+
+- name: Arx Fatalis
+  external:
+    wikipedia: Arx Fatalis
+  meta:
+    genre:
+    - RPG
+
+- name: Ascendancy
+  external:
+    wikipedia: Ascendancy
+  meta:
+    genre:
+    - TBS
+
+- name: Asteroids
+  external:
+    wikipedia: Asteroids (video game)
+  meta:
+    genre:
+    - Arcade
+
+- name: AstroMenace
+  external:
+    wikipedia: AstroMenace
+  meta:
+    genre:
+    - Shmup
+
+- name: Astrosmash
+  external:
+    wikipedia: Astrosmash
+  meta:
+    genre:
+    - Arcade
+
+- name: Asylum
+  external:
+    website: https://www.mobygames.com/game/acorn-32-bit/asylum
+  meta:
+    genre:
+    - Action
+
+- name: Atomic Bomberman
+  external:
+    wikipedia: Atomic Bomberman
+  meta:
+    genre:
+    - Action
+
+- name: Atomix
+  external:
+    wikipedia: Atomix (video game)
+  meta:
+    genre:
+    - Puzzle
+
+- name: Awesomenauts
+  external:
+    wikipedia: Awesomenauts
+  meta:
+    genre:
+    - RPG
+    - RTS
+

--- a/originals/b.yaml
+++ b/originals/b.yaml
@@ -1,147 +1,264 @@
-
-- name: [Babaliba, Dinamic Software]
+- name: Babaliba
+  external:
+    wikipedia: Dinamic Software
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
 - name: Baldur's Gate
+  external:
+    wikipedia: Baldur's Gate
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
-- name: "Baldur's Gate: Tales of the Sword Coast"
+- name: 'Baldur''s Gate II: Shadows of Amn'
+  external:
+    wikipedia: 'Baldur''s Gate II: Shadows of Amn'
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
-- name: "Baldur's Gate II: Shadows of Amn"
+- name: 'Baldur''s Gate II: Throne of Bhaal'
+  external:
+    wikipedia: 'Baldur''s Gate II: Throne of Bhaal'
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
-- name: "Baldur's Gate II: Throne of Bhaal"
+- name: 'Baldur''s Gate: Tales of the Sword Coast'
+  external:
+    wikipedia: 'Baldur''s Gate: Tales of the Sword Coast'
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
 - name: Ballerburg
+  external:
+    wikipedia: Ballerburg
   meta:
-    genre: [Artillery]
+    genre:
+    - Artillery
 
 - name: Balloon Fight
+  external:
+    wikipedia: Balloon Fight
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
 - name: 'Barbarian: The Ultimate Warrior'
+  external:
+    wikipedia: 'Barbarian: The Ultimate Warrior'
   meta:
-    genre: [Fighting, Platform]
-    theme: [Fantasy]
-
-- name: Battle Chess
-  meta:
-    genre: [TBS]
-
-- name: [Battlecity, 'https://github.com/Deceth/Battle-City/wiki/Battle-City-History']
-  meta:
-    genre: [RTS]
-
-- name: [Battle City, Battle City (video game)]
-  meta:
-    genre: [Arcade]
+    genre:
+    - Fighting
+    - Platform
+    theme:
+    - Fantasy
 
 - name: Bard's Tale Contruction Set
+  external:
+    wikipedia: Bard's Tale Contruction Set
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
+
+- name: Battle Chess
+  external:
+    wikipedia: Battle Chess
+  meta:
+    genre:
+    - TBS
+
+- name: Battle City
+  external:
+    wikipedia: Battle City (video game)
+  meta:
+    genre:
+    - Arcade
+
+- name: Battle Isle series
+  external:
+    wikipedia: Battle Isle (series)
+  meta:
+    genre:
+    - TBS
+
+- name: Battle Zone
+  external:
+    wikipedia: Battlezone_(1980_video_game)
+  meta:
+    genre:
+    - FPS
+    - Arcade
+
+- name: Battlecity
+  external:
+    website: https://github.com/Deceth/Battle-City/wiki/Battle-City-History
+  meta:
+    genre:
+    - RTS
 
 - name: BeamNG.drive
+  external:
+    wikipedia: BeamNG.drive
   meta:
-    genre: [Simulation]
+    genre:
+    - Simulation
     subgenre: []
     theme: []
 
 - name: Bermuda Syndrome
+  external:
+    wikipedia: Bermuda Syndrome
   meta:
-    genre: [Adventure, Platform]
+    genre:
+    - Adventure
+    - Platform
 
 - name: Betrayal at Krondor
+  external:
+    wikipedia: Betrayal at Krondor
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
-- name: [Blade Runner, Blade Runner (1997 video game)]
+- name: Blade Runner
+  external:
+    wikipedia: Blade Runner (1997 video game)
   meta:
-    genre: [Adventure]
+    genre:
+    - Adventure
 
 - name: 'Blake Stone: Planet Strike'
+  external:
+    wikipedia: 'Blake Stone: Planet Strike'
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
 
-- name: [Blood, Blood (video game)]
+- name: Blood
+  external:
+    wikipedia: Blood (video game)
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
 
 - name: Bloons Tower Defense
+  external:
+    wikipedia: Bloons Tower Defense
   meta:
-    genre: [RTS]
-    subgenre: [Tower Defense]
+    genre:
+    - RTS
+    subgenre:
+    - Tower Defense
 
 - name: Board Game
+  external:
+    wikipedia: Board Game
   meta:
-    genre: [Compilation]
-    subgenre: [Board Game]
+    genre:
+    - Compilation
+    subgenre:
+    - Board Game
 
-- name: [Bolo, Bolo (1987 video game)]
+- name: Bolo
+  external:
+    wikipedia: Bolo (1987 video game)
   meta:
-    genre: [Shmup]
+    genre:
+    - Shmup
 
 - name: Bomberman
-  names: [Dynablaster]
+  external:
+    wikipedia: Bomberman
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
+  names:
+  - Dynablaster
 
 - name: Boulder Dash
+  external:
+    wikipedia: Boulder Dash
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
-- name: [Bratwurst, 'http://www.mobygames.com/game/bratwurst']
+- name: Brain Blasters
+  external:
+    website: http://www.mobygames.com/game/brain-blasters
   meta:
-    genre: [Arcade]
+    genre:
+    - Puzzle
 
-- name: [Bruce Lee, Bruce Lee (video game)]
+- name: Bratwurst
+  external:
+    website: http://www.mobygames.com/game/bratwurst
   meta:
-    genre: [Action]
+    genre:
+    - Arcade
+
+- name: Breakout
+  external:
+    wikipedia: Breakout (video game)
+  meta:
+    genre:
+    - Arcade
+
+- name: Bruce Lee
+  external:
+    wikipedia: Bruce Lee (video game)
+  meta:
+    genre:
+    - Action
 
 - name: Bubble Bobble
+  external:
+    wikipedia: Bubble Bobble
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
-- name: [Bug Bomber, 'http://www.mobygames.com/game/bug-bomber']
+- name: Bug Bomber
+  external:
+    website: http://www.mobygames.com/game/bug-bomber
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
 - name: BurgerTime
-  names: ["\u30D0\u30FC\u30AC\u30FC\u30BF\u30A4\u30E0", Hamburger, "\u30CF\u30F3\u30D0\
-      \u30FC\u30AC\u30FC"]
+  external:
+    wikipedia: BurgerTime
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
+  names:
+  - "\u30D0\u30FC\u30AC\u30FC\u30BF\u30A4\u30E0"
+  - Hamburger
+  - "\u30CF\u30F3\u30D0\u30FC\u30AC\u30FC"
 
 - name: Buster Bros
+  external:
+    wikipedia: Buster Bros
   meta:
-    genre: [Arcade]
-  names: [Pang, "\u30D1\u30F3", Pomping World, "\u30DD\u30F3\u30D4\u30F3\u30B0\u30FB\
-      \u30EF\u30FC\u30EB\u30C9"]
+    genre:
+    - Arcade
+  names:
+  - Pang
+  - "\u30D1\u30F3"
+  - Pomping World
+  - "\u30DD\u30F3\u30D4\u30F3\u30B0\u30FB\u30EF\u30FC\u30EB\u30C9"
 
 - name: Buzz Aldrin's Race Into Space
+  external:
+    wikipedia: Buzz Aldrin's Race Into Space
   meta:
-    genre: [Strategy, Simulation, TBS]
-    theme: [Management]
+    genre:
+    - Strategy
+    - Simulation
+    - TBS
+    theme:
+    - Management
 
-- name: [Battle Isle series, Battle Isle (series)]
-  meta:
-    genre: [TBS]
-
-- name: [Battle Zone, Battlezone_(1980_video_game)]
-  meta:
-    genre: [FPS, Arcade]
-
-- name: [Brain Blasters, 'http://www.mobygames.com/game/brain-blasters']
-  meta:
-    genre: [Puzzle]
-
-- name: [Breakout, Breakout (video game)]
-  meta:
-    genre: [Arcade]

--- a/originals/c.yaml
+++ b/originals/c.yaml
@@ -1,192 +1,354 @@
-
-- name: [Cadaver, Cadaver (video game)]
+- name: C-Dogs
+  external:
+    wikipedia: C-Dogs
   meta:
-    genre: [Action, Adventure]
+    genre:
+    - Shmup
+    subgenre:
+    - Run and gun
+
+- name: Cadaver
+  external:
+    wikipedia: Cadaver (video game)
+  meta:
+    genre:
+    - Action
+    - Adventure
 
 - name: Caesar 3
+  external:
+    wikipedia: Caesar 3
   meta:
-    genre: [Simulation, Strategy]
-    subgenre: [City Building]
-    theme: [Management]
+    genre:
+    - Simulation
+    - Strategy
+    subgenre:
+    - City Building
+    theme:
+    - Management
 
 - name: Call to Power II
+  external:
+    wikipedia: Call to Power II
   meta:
-    genre: [TBS]
+    genre:
+    - TBS
 
 - name: Candy Crush Saga
+  external:
+    wikipedia: Candy Crush Saga
   meta:
-    genre: [Puzzle]
+    genre:
+    - Puzzle
 
-- name: [Cannon Fodder, Cannon Fodder (series)]
+- name: Cannon Fodder
+  external:
+    wikipedia: Cannon Fodder (series)
   meta:
-    genre: [Action, RTS, Shmup]
+    genre:
+    - Action
+    - RTS
+    - Shmup
 
 - name: Carmageddon
+  external:
+    wikipedia: Carmageddon
   meta:
-    genre: [Racing]
+    genre:
+    - Racing
 
 - name: Castle of the Winds
+  external:
+    wikipedia: Castle of the Winds
   meta:
-    genre: [Roguelike]
+    genre:
+    - Roguelike
 
-- name: [Cataclysm, 'http://cataclysmrl.blogspot.com/']
+- name: Cataclysm
+  external:
+    website: http://cataclysmrl.blogspot.com/
   meta:
-    genre: [Roguelike]
-    subgenre: [Survival]
-    theme: [Horror]
+    genre:
+    - Roguelike
+    subgenre:
+    - Survival
+    theme:
+    - Horror
 
-- name: [Catacomb, Catacomb (video game)]
+- name: Catacomb
+  external:
+    wikipedia: Catacomb (video game)
   meta:
-    genre: [Action, TPS]
-    theme: [Fantasy]
+    genre:
+    - Action
+    - TPS
+    theme:
+    - Fantasy
 
 - name: Catacomb II
+  external:
+    wikipedia: Catacomb II
   meta:
-    genre: [Action, TPS]
-    theme: [Fantasy]
+    genre:
+    - Action
+    - TPS
+    theme:
+    - Fantasy
 
 - name: Cave Story
-  names: [Doukutsu Monogatari]
+  external:
+    wikipedia: Cave Story
   meta:
-    genre: [Adventure, Platform]
-    theme: [Sci-Fi]
+    genre:
+    - Adventure
+    - Platform
+    theme:
+    - Sci-Fi
+  names:
+  - Doukutsu Monogatari
 
 - name: Chip's Challenge
+  external:
+    wikipedia: Chip's Challenge
   meta:
-    genre: [Puzzle]
+    genre:
+    - Puzzle
 
 - name: ChuChu Rocket!
+  external:
+    wikipedia: ChuChu Rocket!
   meta:
-    genre: [Puzzle, Action]
+    genre:
+    - Puzzle
+    - Action
 
-- name: [Circus Atari, Circus (video game)]
+- name: Circus Atari
+  external:
+    wikipedia: Circus (video game)
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
-- name: [Claw, Claw (video game)]
+- name: Civilization
+  external:
+    wikipedia: Civilization (video game)
   meta:
-    genre: [Platform]
+    genre:
+    - TBS
+
+- name: Civilization II
+  external:
+    wikipedia: Civilization II
+  meta:
+    genre:
+    - TBS
+    subgenre:
+    - 4X
+    theme:
+    - Alternate Historical
+    - Management
+
+- name: Claw
+  external:
+    wikipedia: Claw (video game)
+  meta:
+    genre:
+    - Platform
 
 - name: Clonk
+  external:
+    wikipedia: Clonk
   meta:
-    genre: [Action, Platform, RTS]
+    genre:
+    - Action
+    - Platform
+    - RTS
 
-- name: [Columns, Columns (video game)]
+- name: Columns
+  external:
+    wikipedia: Columns (video game)
   meta:
-    genre: [Puzzle]
-
-- name: [Commando, Commando (video game)]
-  meta:
-    genre: [Shmup]
-
-- name: [Commander Keen Series, Commander Keen]
-  meta:
-    genre: [Platform]
+    genre:
+    - Puzzle
 
 - name: Command & Conquer
+  external:
+    wikipedia: Command & Conquer
   meta:
-    genre: [RTS]
-    theme: [Modern Military]
-
-- name: 'Command & Conquer: Red Alert'
-  meta:
-    genre: [RTS]
-    theme: [Modern Military]
+    genre:
+    - RTS
+    theme:
+    - Modern Military
 
 - name: 'Command & Conquer: Generals'
+  external:
+    wikipedia: 'Command & Conquer: Generals'
   meta:
-    genre: [RTS]
-    theme: [Sci-Fi, Modern Military]
+    genre:
+    - RTS
+    theme:
+    - Sci-Fi
+    - Modern Military
+
+- name: 'Command & Conquer: Red Alert'
+  external:
+    wikipedia: 'Command & Conquer: Red Alert'
+  meta:
+    genre:
+    - RTS
+    theme:
+    - Modern Military
+
+- name: Commander Keen Series
+  external:
+    wikipedia: Commander Keen
+  meta:
+    genre:
+    - Platform
+
+- name: Commando
+  external:
+    wikipedia: Commando (video game)
+  meta:
+    genre:
+    - Shmup
 
 - name: Company of Heroes
+  external:
+    wikipedia: Company of Heroes
   meta:
-    genre: [RTS]
-    theme: [World War II]
+    genre:
+    - RTS
+    theme:
+    - World War II
+
+- name: Company of Heroes 2
+  external:
+    wikipedia: Company of Heroes 2
+  meta:
+    genre:
+    - RTS
+    theme:
+    - World War II
 
 - name: 'Company of Heroes: Opposing Fronts'
+  external:
+    wikipedia: 'Company of Heroes: Opposing Fronts'
   meta:
-    genre: [RTS]
-    theme: [World War II]
+    genre:
+    - RTS
+    theme:
+    - World War II
 
 - name: 'Company of Heroes: Tales of Valor'
+  external:
+    wikipedia: 'Company of Heroes: Tales of Valor'
   meta:
-    genre: [RTS]
-    theme: [World War II]
+    genre:
+    - RTS
+    theme:
+    - World War II
 
-- name: 'Company of Heroes 2'
+- name: Contra
+  external:
+    wikipedia: Contra (video game)
   meta:
-    genre: [RTS]
-    theme: [World War II]
-
-- name: [Contra, Contra (video game)]
-  meta:
-    genre: [Platform]
+    genre:
+    - Platform
 
 - name: Cookie Clicker
+  external:
+    wikipedia: Cookie Clicker
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
 - name: Cosmic Ark
+  external:
+    wikipedia: Cosmic Ark
   meta:
-    genre: [Action]
+    genre:
+    - Action
 
-- name: [Crazy Cars, Titus Software]
+- name: Crazy Cars
+  external:
+    wikipedia: Titus Software
   meta:
-    genre: [Racing]
+    genre:
+    - Racing
 
 - name: Crazy Machines
+  external:
+    wikipedia: Crazy Machines
   meta:
-    genre: [Puzzle, Simulation]
-
-- name: 'Crazy Machines: The Wacky Contraptions Game'
-  meta:
-    genre: [Puzzle, Simulation]
+    genre:
+    - Puzzle
+    - Simulation
 
 - name: Crazy Machines 2
+  external:
+    wikipedia: Crazy Machines 2
   meta:
-    genre: [Puzzle, Simulation]
+    genre:
+    - Puzzle
+    - Simulation
 
-- name: [Creatures, Creatures (video game)]
+- name: 'Crazy Machines: The Wacky Contraptions Game'
+  external:
+    wikipedia: 'Crazy Machines: The Wacky Contraptions Game'
   meta:
-    genre: [Puzzle]
+    genre:
+    - Puzzle
+    - Simulation
+
+- name: Creatures
+  external:
+    wikipedia: Creatures (video game)
+  meta:
+    genre:
+    - Puzzle
+
+- name: Crimsonland
+  external:
+    wikipedia: Crimsonland
+  meta:
+    genre:
+    - Shmup
+
+- name: Crystal Caves
+  external:
+    wikipedia: Crystal Caves
+  meta:
+    genre:
+    - Platform
 
 - name: Crystal Quest
+  external:
+    wikipedia: Crystal Quest
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
 - name: 'Cube 2: Sauerbraten'
+  external:
+    wikipedia: 'Cube 2: Sauerbraten'
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
     subgenre: []
     theme: []
 
 - name: Curse of the Azure Bonds
+  external:
+    wikipedia: Curse of the Azure Bonds
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
-- name: [Cytadela, 'http://www.ppa.pl/gry/cytadela.html']
+- name: Cytadela
+  external:
+    website: http://www.ppa.pl/gry/cytadela.html
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
 
-- name: C-Dogs
-  meta:
-    genre: [Shmup]
-    subgenre: [Run and gun]
-
-- name: [Civilization, Civilization (video game)]
-  meta:
-    genre: [TBS]
-
-- name: Civilization II
-  meta:
-    genre: [TBS]
-    subgenre: [4X]
-    theme: [Alternate Historical, Management]
-
-- name: Crimsonland
-  meta:
-    genre: [Shmup]
-
-- name: Crystal Caves
-  meta:
-    genre: [Platform]

--- a/originals/d.yaml
+++ b/originals/d.yaml
@@ -1,163 +1,299 @@
+- name: Dance Dance Revolution
+  external:
+    wikipedia: Dance Dance Revolution
+  meta:
+    genre:
+    - Rhythm
+
+- name: Dandy
+  external:
+    wikipedia: Dandy (video game)
+  meta:
+    genre:
+    - Arcade
 
 - name: Dark Forces
+  external:
+    wikipedia: Dark Forces
   meta:
-    genre: [FPS]
-
-- name: Dance Dance Revolution
-  meta:
-    genre: [Rhythm]
-
-- name: [Dandy, Dandy (video game)]
-  meta:
-    genre: [Arcade]
+    genre:
+    - FPS
 
 - name: Dark Reign 2
+  external:
+    wikipedia: Dark Reign 2
   meta:
-    genre: [RTS]
+    genre:
+    - RTS
 
-- name: [Defender, Defender (video game)]
+- name: DEFCON
+  external:
+    wikipedia: DEFCON_(video_game)
   meta:
-    genre: [Arcade]
+    genre:
+    - RTS
 
-- name: [Descent, Descent (video game)]
+- name: Defender
+  external:
+    wikipedia: Defender (video game)
   meta:
-    genre: [FPS]
-
-- name: Descent II
-  meta:
-    genre: [FPS]
-
-- name: ['DesertStrike: Return to the Gulf', Jungle Strike]
-  meta:
-    genre: [Shmup]
-
-- name: [Destructo, 'http://www.mobygames.com/game/destructo']
-  names:
-  - [Island of Dr. Destructo, 'http://www.mobygames.com/game/destructo']
-  - [The Island of Doctor Destructo, 'http://www.mobygames.com/game/destructo']
-  meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
 - name: Deflektor
+  external:
+    wikipedia: Deflektor
   meta:
-    genre: [Puzzle]
+    genre:
+    - Puzzle
+
+- name: Descent
+  external:
+    wikipedia: Descent (video game)
+  meta:
+    genre:
+    - FPS
+
+- name: Descent II
+  external:
+    wikipedia: Descent II
+  meta:
+    genre:
+    - FPS
+
+- name: 'DesertStrike: Return to the Gulf'
+  external:
+    wikipedia: Jungle Strike
+  meta:
+    genre:
+    - Shmup
 
 - name: 'Desperados: Wanted Dead or Alive'
+  external:
+    wikipedia: 'Desperados: Wanted Dead or Alive'
   meta:
-    genre: [RTS]
+    genre:
+    - RTS
 
-- name: [Diablo, Diablo (series)]
+- name: Destructo
+  external:
+    website: http://www.mobygames.com/game/destructo
   meta:
-    genre: [RPG, Action]
-    theme: [Horror, Fantasy, Medieval]
-
-- name: Diablo II
-  platform: [Windows]
-  meta:
-    genre: [RPG, Action]
-    subgenre: [Action RPG]
-    theme: [Fantasy, Medieval]
-
-- name: [Digger, Digger (video game)]
-  meta:
-    genre: [Arcade]
-
-- name: Digimon World
-  meta:
-    genre: [RPG]
-
-- name: [Dodger, 'http://www.mobygames.com/game/win3x/dodger']
-  meta:
-    genre: [Arcade]
-
-- name: [Dogs of War, Dogs of War (1989 video game)]
-  meta:
-    genre: [Shmup]
-
-- name: Doom
-  meta:
-    genre: [FPS]
-
-- name: Doom II
-  meta:
-    genre: [FPS]
-
-- name: Doom 64
-  meta:
-    genre: [FPS]
-
-- name: [Doom 3, Doom_3]
-  meta:
-    genre: [FPS]
-
-- name: Drugwars
-  meta:
-    genre: [Strategy, TBS]
-    theme: [Crime]
+    genre:
+    - Arcade
+  names:
+  - Island of Dr. Destructo
+  - The Island of Doctor Destructo
 
 - name: Deuteros
+  external:
+    wikipedia: Deuteros
   meta:
-    genre: [RTS]
+    genre:
+    - RTS
+
+- name: Diablo
+  external:
+    wikipedia: Diablo (series)
+  meta:
+    genre:
+    - RPG
+    - Action
+    theme:
+    - Horror
+    - Fantasy
+    - Medieval
+
+- name: Diablo II
+  external:
+    wikipedia: Diablo II
+  meta:
+    genre:
+    - RPG
+    - Action
+    subgenre:
+    - Action RPG
+    theme:
+    - Fantasy
+    - Medieval
+  platform:
+  - Windows
+
+- name: Digger
+  external:
+    wikipedia: Digger (video game)
+  meta:
+    genre:
+    - Arcade
+
+- name: Digimon World
+  external:
+    wikipedia: Digimon World
+  meta:
+    genre:
+    - RPG
 
 - name: Dink Smallwood
+  external:
+    wikipedia: Dink Smallwood
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
-- name: 'Dragon Age: Origins'
+- name: Dodger
+  external:
+    website: http://www.mobygames.com/game/win3x/dodger
   meta:
-    genre: [RPG]
-    theme: [Fantasy]
+    genre:
+    - Arcade
+
+- name: Dogs of War
+  external:
+    wikipedia: Dogs of War (1989 video game)
+  meta:
+    genre:
+    - Shmup
+
+- name: Doom
+  external:
+    wikipedia: Doom
+  meta:
+    genre:
+    - FPS
+
+- name: Doom 3
+  external:
+    wikipedia: Doom_3
+  meta:
+    genre:
+    - FPS
+
+- name: Doom 64
+  external:
+    wikipedia: Doom 64
+  meta:
+    genre:
+    - FPS
+
+- name: Doom II
+  external:
+    wikipedia: Doom II
+  meta:
+    genre:
+    - FPS
 
 - name: Dragon Age II
+  external:
+    wikipedia: Dragon Age II
   meta:
-    genre: [RPG]
-    theme: [Fantasy]
+    genre:
+    - RPG
+    theme:
+    - Fantasy
+
+- name: 'Dragon Age: Origins'
+  external:
+    wikipedia: 'Dragon Age: Origins'
+  meta:
+    genre:
+    - RPG
+    theme:
+    - Fantasy
 
 - name: 'Drakan: Order of the Flame'
-  platform: [Windows]
+  external:
+    wikipedia: 'Drakan: Order of the Flame'
   meta:
-    genre: [Action, Adventure]
-    theme: [Fantasy, Medieval]
+    genre:
+    - Action
+    - Adventure
+    theme:
+    - Fantasy
+    - Medieval
+  platform:
+  - Windows
+
+- name: Drugwars
+  external:
+    wikipedia: Drugwars
+  meta:
+    genre:
+    - Strategy
+    - TBS
+    theme:
+    - Crime
 
 - name: Duck Hunt
+  external:
+    wikipedia: Duck Hunt
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
-- name: [Duke Nukem, Duke Nukem (video game)]
+- name: Duke Nukem
+  external:
+    wikipedia: Duke Nukem (video game)
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
 
 - name: Duke Nukem 3D
+  external:
+    wikipedia: Duke Nukem 3D
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
 
 - name: Dune 2
+  external:
+    wikipedia: Dune 2
   meta:
-    genre: [RTS]
-    theme: [Sci-Fi]
+    genre:
+    - RTS
+    theme:
+    - Sci-Fi
 
 - name: Dune 2000
+  external:
+    wikipedia: Dune 2000
   meta:
-    genre: [RTS]
-    theme: [Sci-Fi]
+    genre:
+    - RTS
+    theme:
+    - Sci-Fi
 
 - name: Dungeon Keeper
+  external:
+    wikipedia: Dungeon Keeper
   meta:
-    genre: [Strategy, RTS]
-    theme: [Horror, Fantasy, Comedy]
+    genre:
+    - Strategy
+    - RTS
+    theme:
+    - Horror
+    - Fantasy
+    - Comedy
 
 - name: Dungeon Keeper 2
+  external:
+    wikipedia: Dungeon Keeper 2
   meta:
-    genre: [Simulation, RTS]
+    genre:
+    - Simulation
+    - RTS
 
-- name: [Dungeon Master, Dungeon Master (video game)]
+- name: Dungeon Master
+  external:
+    wikipedia: Dungeon Master (video game)
   meta:
-    genre: [RPG, Action]
+    genre:
+    - RPG
+    - Action
 
 - name: DX-Ball
+  external:
+    wikipedia: DX-Ball
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
-- name: [DEFCON, DEFCON_(video_game)]
-  meta:
-    genre: [RTS]

--- a/originals/e.yaml
+++ b/originals/e.yaml
@@ -1,81 +1,156 @@
-
-- name: [E.T. the Extra-Terrestrial, E.T. the Extra-Terrestrial (video game)]
+- name: E.T. the Extra-Terrestrial
+  external:
+    wikipedia: E.T. the Extra-Terrestrial (video game)
   meta:
-    genre: [Arcade, Adventure]
+    genre:
+    - Arcade
+    - Adventure
 
-- name: [Earth Shaker, Earth Shaker (video game)]
+- name: Earth Shaker
+  external:
+    wikipedia: Earth Shaker (video game)
   meta:
-    genre: [Puzzle]
+    genre:
+    - Puzzle
 
-- name: [Eat The Whistle, Eat the whistle (video game)]
+- name: Eat The Whistle
+  external:
+    wikipedia: Eat the whistle (video game)
   meta:
-    genre: [Sports]
-    subgenre: [Soccer]
+    genre:
+    - Sports
+    subgenre:
+    - Soccer
 
 - name: Echochrome
-  names: ["Mugen Kair\u014D", "\u7121\u9650\u56DE\u5ECA"]
+  external:
+    wikipedia: Echochrome
   meta:
-    genre: [Puzzle]
-
-- name: [Elements, 'http://www.mobygames.com/game/browser/elements_']
-  meta:
-    genre: [TBS]
-
-- name: [Encounter, Encounter (video game)]
-  meta:
-    genre: [Shmup]
-
-- name: [Entombed!, Entombed (1982 video game)]
-  meta:
-    genre: [Adventure]
-
-- name: Escape from Colditz
-  meta:
-    genre: [Action, Adventure]
-
-- name: Eye of the Beholder II
-  meta:
-    genre: [RPG, Action]
+    genre:
+    - Puzzle
+  names:
+  - "Mugen Kair\u014D"
+  - "\u7121\u9650\u56DE\u5ECA"
 
 - name: Elasto Mania
+  external:
+    wikipedia: Elasto Mania
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
+
+- name: Elements
+  external:
+    website: http://www.mobygames.com/game/browser/elements_
+  meta:
+    genre:
+    - TBS
+
+- name: Elite
+  external:
+    wikipedia: Elite_(video_game)
+  meta:
+    genre:
+    - Action
+    - Simulation
+    subgenre:
+    - Flight Simulator
+    theme:
+    - Sci-Fi
+
+- name: Elite II
+  external:
+    wikipedia: 'Frontier: Elite II'
+  meta:
+    genre:
+    - Action
+    - Simulation
+    subgenre:
+    - Flight Simulator
+    theme:
+    - Sci-Fi
+    - Espionage
+
+- name: Elite III
+  external:
+    wikipedia: 'Frontier: First Encounters'
+  meta:
+    genre:
+    - Action
+    - Simulation
+    subgenre:
+    - Flight Simulator
+    theme:
+    - Sci-Fi
+    - Espionage
+  names:
+  - 'Frontier: First Encounters'
+  - FFE
 
 - name: Emperor of the Fading Suns
+  external:
+    wikipedia: Emperor of the Fading Suns
   meta:
-    genre: [TBS]
+    genre:
+    - TBS
 
-- name: [Exile 1988, Exile_(1988_video_game)]
+- name: Encounter
+  external:
+    wikipedia: Encounter (video game)
   meta:
-    genre: [Action, Adventure]
+    genre:
+    - Shmup
 
-- name: Exolon
+- name: Entombed!
+  external:
+    wikipedia: Entombed (1982 video game)
   meta:
-    genre: [Shmup]
+    genre:
+    - Adventure
 
-- name: [Elite, Elite_(video_game)]
+- name: Escape from Colditz
+  external:
+    wikipedia: Escape from Colditz
   meta:
-    genre: [Action, Simulation]
-    subgenre: [Flight Simulator]
-    theme: [Sci-Fi]
-
-- name: [Elite II, 'Frontier: Elite II']
-  meta:
-    genre: [Action, Simulation]
-    subgenre: [Flight Simulator]
-    theme: [Sci-Fi, Espionage]
-
-- name: [Elite III, 'Frontier: First Encounters']
-  names: ['Frontier: First Encounters', FFE]
-  meta:
-    genre: [Action, Simulation]
-    subgenre: [Flight Simulator]
-    theme: [Sci-Fi, Espionage]
+    genre:
+    - Action
+    - Adventure
 
 - name: Escape from Monkey Island
+  external:
+    wikipedia: Escape from Monkey Island
   meta:
-    genre: [Adventure]
+    genre:
+    - Adventure
 
-- name: [Escape Velocity, Escape Velocity (video game)]
+- name: Escape Velocity
+  external:
+    wikipedia: Escape Velocity (video game)
   meta:
-    genre: [Action, Simulation]
+    genre:
+    - Action
+    - Simulation
+
+- name: Exile 1988
+  external:
+    wikipedia: Exile_(1988_video_game)
+  meta:
+    genre:
+    - Action
+    - Adventure
+
+- name: Exolon
+  external:
+    wikipedia: Exolon
+  meta:
+    genre:
+    - Shmup
+
+- name: Eye of the Beholder II
+  external:
+    wikipedia: Eye of the Beholder II
+  meta:
+    genre:
+    - RPG
+    - Action
+

--- a/originals/f.yaml
+++ b/originals/f.yaml
@@ -1,111 +1,207 @@
-
-- name: [F-1 Spirit, F-1 Spirit (series)]
+- name: F-1 Spirit
+  external:
+    wikipedia: F-1 Spirit (series)
   meta:
-    genre: [Sports, Racing]
-    theme: [Motorsports]
+    genre:
+    - Sports
+    - Racing
+    theme:
+    - Motorsports
 
 - name: F-Zero
+  external:
+    wikipedia: F-Zero
   meta:
-    genre: [Racing]
+    genre:
+    - Racing
 
-- name: [Fade to Black, Fade to Black (video game)]
+- name: Fade to Black
+  external:
+    wikipedia: Fade to Black (video game)
   meta:
-    genre: [Action, Adventure]
+    genre:
+    - Action
+    - Adventure
+
+- name: Falcon
+  external:
+    wikipedia: Falcon (video game series)
+  meta:
+    genre:
+    - Simulation
+
+- name: Fall Down
+  external:
+    website: http://www.mobygames.com/game/fall-down
+  meta:
+    genre:
+    - Arcade
 
 - name: Fallout 2
+  external:
+    wikipedia: Fallout 2
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
-- name: ['Fallout 3: Van Buren', Van Buren (video game)]
+- name: 'Fallout 3: Van Buren'
+  external:
+    wikipedia: Van Buren (video game)
   meta:
-    genre: [RPG]
-
-- name: 'Fallout Tactics: Brotherhood of Steel'
-  meta:
-    genre: [RTS]
+    genre:
+    - RPG
 
 - name: Fallout Online
+  external:
+    wikipedia: Fallout Online
   meta:
-    genre: [MMORPG]
+    genre:
+    - MMORPG
+
+- name: 'Fallout Tactics: Brotherhood of Steel'
+  external:
+    wikipedia: 'Fallout Tactics: Brotherhood of Steel'
+  meta:
+    genre:
+    - RTS
 
 - name: Fantastic Journey
+  external:
+    wikipedia: Fantastic Journey
   meta:
-    genre: [Shmup]
-  names: ["Gokuj\u014D Parodius!"]
-
-- name: Fire Power
-  platform: [Amiga, Commodore 64, MS-DOS]
-  meta:
-    genre: [Action]
-
-- name: Flappy Bird
-  meta:
-    genre: [Arcade, Platform]
-
-- name: [Flashback, Flashback (1992 video game)]
-  meta:
-    genre: [Adventure, Platform]
-
-- name: [Floor 13, Floor 13 (video game)]
-  meta:
-    genre: [TBS]
-
-- name: Flying Shark
-  meta:
-    genre: [Shmup]
+    genre:
+    - Shmup
+  names:
+  - "Gokuj\u014D Parodius!"
 
 - name: Final Fantasy VIII
+  external:
+    wikipedia: Final Fantasy VIII
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
-- name: [Flag Catcher, 'http://hol.abime.net/5578']
+- name: Fire Power
+  external:
+    wikipedia: Fire Power
   meta:
-    genre: [Puzzle]
+    genre:
+    - Action
+  platform:
+  - Amiga
+  - Commodore 64
+  - MS-DOS
 
-- name: [Football Manager, Football Manager (1982 series)]
+- name: Flag Catcher
+  external:
+    website: http://hol.abime.net/5578
   meta:
-    genre: [Simulation, Strategy, Sports]
-    subgenre: [Soccer]
-    theme: [Management]
+    genre:
+    - Puzzle
+
+- name: Flappy Bird
+  external:
+    wikipedia: Flappy Bird
+  meta:
+    genre:
+    - Arcade
+    - Platform
+
+- name: Flashback
+  external:
+    wikipedia: Flashback (1992 video game)
+  meta:
+    genre:
+    - Adventure
+    - Platform
+
+- name: Floor 13
+  external:
+    wikipedia: Floor 13 (video game)
+  meta:
+    genre:
+    - TBS
+
+- name: Flying Shark
+  external:
+    wikipedia: Flying Shark
+  meta:
+    genre:
+    - Shmup
+
+- name: Football Manager
+  external:
+    wikipedia: Football Manager (1982 series)
+  meta:
+    genre:
+    - Simulation
+    - Strategy
+    - Sports
+    subgenre:
+    - Soccer
+    theme:
+    - Management
 
 - name: 'Forgotten Realms: Unlimited Adventures'
+  external:
+    wikipedia: 'Forgotten Realms: Unlimited Adventures'
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
-- name: [Forsaken, Forsaken (video game)]
+- name: Forsaken
+  external:
+    wikipedia: Forsaken (video game)
   meta:
-    genre: [FPS]
-    theme: [Sci-Fi, Post-Apocalyptic]
+    genre:
+    - FPS
+    theme:
+    - Sci-Fi
+    - Post-Apocalyptic
+
+- name: Freelancer
+  external:
+    wikipedia: Freelancer (video game)
+  meta:
+    genre:
+    - Action
+    - Simulation
+    - TPS
+    theme:
+    - Sci-Fi
 
 - name: FreeSpace 2
+  external:
+    wikipedia: FreeSpace 2
   meta:
-    genre: [Action, Simulation]
-    theme: [Sci-Fi]
+    genre:
+    - Action
+    - Simulation
+    theme:
+    - Sci-Fi
 
-- name: [Freelancer, Freelancer (video game)]
+- name: Frog!
+  external:
+    website: http://www.mobygames.com/game/frog
   meta:
-    genre: [Action, Simulation, TPS]
-    theme: [Sci-Fi]
-
-- name: [Frog!, 'http://www.mobygames.com/game/frog']
+    genre:
+    - Arcade
   names:
-  - [Back To Nature, 'http://www.mobygames.com/game/frog']
-  meta:
-    genre: [Arcade]
-
-- name: Frogs and Flies
-  meta:
-    genre: [Arcade]
-  names: [Frog Bog]
+  - Back To Nature
 
 - name: Frogger
+  external:
+    wikipedia: Frogger
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
-- name: [Fall Down, 'http://www.mobygames.com/game/fall-down']
+- name: Frogs and Flies
+  external:
+    wikipedia: Frogs and Flies
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
+  names:
+  - Frog Bog
 
-- name: [Falcon, Falcon (video game series)]
-  meta:
-    genre: [Simulation]

--- a/originals/g.yaml
+++ b/originals/g.yaml
@@ -1,68 +1,128 @@
-
 - name: Galaxian
+  external:
+    wikipedia: Galaxian
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
 - name: Geometry Wars
+  external:
+    wikipedia: Geometry Wars
   meta:
-    genre: [Shmup]
+    genre:
+    - Shmup
 
-- name: [Gish, Gish (video game)]
+- name: Gish
+  external:
+    wikipedia: Gish (video game)
   meta:
-    genre: [Platform]
-    theme: [Comedy]
+    genre:
+    - Platform
+    theme:
+    - Comedy
 
 - name: Gladiator
+  external:
+    wikipedia: Gladiator
   meta:
-    genre: [Action, RPG]
+    genre:
+    - Action
+    - RPG
 
 - name: Glest
+  external:
+    wikipedia: Glest
   meta:
-    genre: [RTS]
-    theme: [Medieval, Fantasy]
+    genre:
+    - RTS
+    theme:
+    - Medieval
+    - Fantasy
 
-- name: [Gods, Gods (video game)]
+- name: Gods
+  external:
+    wikipedia: Gods (video game)
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
 
-- name: [GoldenEye 007, GoldenEye 007 (1997 video game)]
+- name: GoldenEye 007
+  external:
+    wikipedia: GoldenEye 007 (1997 video game)
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
 
-- name: [Gorillas, Gorillas (video game)]
+- name: Gorillas
+  external:
+    wikipedia: Gorillas (video game)
   meta:
-    genre: [Arcade, Artillery]
+    genre:
+    - Arcade
+    - Artillery
 
-- name: [Gothic, Gothic (video game)]
+- name: Gothic
+  external:
+    wikipedia: Gothic (video game)
   meta:
-    genre: [RPG, Action]
+    genre:
+    - RPG
+    - Action
 
 - name: Gothic II
+  external:
+    wikipedia: Gothic II
   meta:
-    genre: [RPG, Action]
+    genre:
+    - RPG
+    - Action
 
-- name: Grim Fandango
+- name: Grand Theft Auto
+  external:
+    wikipedia: Grand Theft Auto (video game)
   meta:
-    genre: [Adventure]
-
-- name: [Grand Theft Auto, Grand Theft Auto (video game)]
-  meta:
-    genre: [Action, Adventure]
-    theme: [Crime]
+    genre:
+    - Action
+    - Adventure
+    theme:
+    - Crime
 
 - name: Grand Theft Auto 2
+  external:
+    wikipedia: Grand Theft Auto 2
   meta:
-    genre: [Action, Adventure]
-    theme: [Crime]
+    genre:
+    - Action
+    - Adventure
+    theme:
+    - Crime
 
 - name: Grand Theft Auto III
+  external:
+    wikipedia: Grand Theft Auto III
   meta:
-    genre: [Action, Adventure]
+    genre:
+    - Action
+    - Adventure
 
 - name: Gravity Force
+  external:
+    wikipedia: Gravity Force
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
+
+- name: Grim Fandango
+  external:
+    wikipedia: Grim Fandango
+  meta:
+    genre:
+    - Adventure
 
 - name: Guitar Hero
+  external:
+    wikipedia: Guitar Hero
   meta:
-    genre: [Rhythm]
+    genre:
+    - Rhythm
+

--- a/originals/h.yaml
+++ b/originals/h.yaml
@@ -1,75 +1,138 @@
-
-- name: [Hardwar, Hardwar (video game)]
+- name: Hack
+  external:
+    wikipedia: Hack (video game)
   meta:
-    genre: [Action, Simulation]
-    subgenre: [Flight Simulator]
-    theme: [Sci-Fi, Cyberpunk]
+    genre:
+    - Roguelike
+
+- name: Hardwar
+  external:
+    wikipedia: Hardwar (video game)
+  meta:
+    genre:
+    - Action
+    - Simulation
+    subgenre:
+    - Flight Simulator
+    theme:
+    - Sci-Fi
+    - Cyberpunk
 
 - name: Haunted House
+  external:
+    wikipedia: Haunted House
   meta:
-    genre: [Action, Adventure]
-    subgenre: [Survival]
-    theme: [Horror]
+    genre:
+    - Action
+    - Adventure
+    subgenre:
+    - Survival
+    theme:
+    - Horror
 
-- name: [Head over Heels, Head over Heels (video game)]
+- name: Head over Heels
+  external:
+    wikipedia: Head over Heels (video game)
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
 
-- name: [Heart of Darkness, Heart of Darkness (video game)]
+- name: Heart of Darkness
+  external:
+    wikipedia: Heart of Darkness (video game)
   meta:
-    genre: [Platform, Adventure]
+    genre:
+    - Platform
+    - Adventure
 
-- name: [Heavy Smash, 'http://www.mobygames.com/game/arcade/heavy-smash']
+- name: Heavy Smash
+  external:
+    website: http://www.mobygames.com/game/arcade/heavy-smash
   meta:
-    genre: [Sports]
-    subgenre: [Handball]
-    theme: [Sci-Fi]
+    genre:
+    - Sports
+    subgenre:
+    - Handball
+    theme:
+    - Sci-Fi
 
-- name: Hexen
+- name: Heretic
+  external:
+    wikipedia: Heretic (video game)
   meta:
-    genre: [FPS]
-
-- name: Hexen II
-  meta:
-    genre: [FPS]
-
-- name: [Heretic, Heretic (video game)]
-  meta:
-    genre: [FPS]
+    genre:
+    - FPS
 
 - name: Heroes of Might and Magic II
+  external:
+    wikipedia: Heroes of Might and Magic II
   meta:
-    genre: [TBS]
+    genre:
+    - TBS
 
 - name: Heroes of Might and Magic III
+  external:
+    wikipedia: Heroes of Might and Magic III
   meta:
-    genre: [TBS]
-
-- name: Highway Encounter
-  meta:
-    genre: [RTS]
-
-- name: 'History Line: 1914-1918'
-  meta:
-    genre: [Strategy, Turn-Based Tactics]
-    theme: [World War I]
-
-- name: Homeworld
-  meta:
-    genre: [RTS]
-
-- name: HoverRace
-  meta:
-    genre: [Racing]
-
-- name: Hovertank 3D
-  meta:
-    genre: [FPS]
+    genre:
+    - TBS
 
 - name: Herzog Zwei
+  external:
+    wikipedia: Herzog Zwei
   meta:
-    genre: [RTS]
+    genre:
+    - RTS
 
-- name: [Hack, Hack (video game)]
+- name: Hexen
+  external:
+    wikipedia: Hexen
   meta:
-    genre: [Roguelike]
+    genre:
+    - FPS
+
+- name: Hexen II
+  external:
+    wikipedia: Hexen II
+  meta:
+    genre:
+    - FPS
+
+- name: Highway Encounter
+  external:
+    wikipedia: Highway Encounter
+  meta:
+    genre:
+    - RTS
+
+- name: 'History Line: 1914-1918'
+  external:
+    wikipedia: 'History Line: 1914-1918'
+  meta:
+    genre:
+    - Strategy
+    - Turn-Based Tactics
+    theme:
+    - World War I
+
+- name: Homeworld
+  external:
+    wikipedia: Homeworld
+  meta:
+    genre:
+    - RTS
+
+- name: HoverRace
+  external:
+    wikipedia: HoverRace
+  meta:
+    genre:
+    - Racing
+
+- name: Hovertank 3D
+  external:
+    wikipedia: Hovertank 3D
+  meta:
+    genre:
+    - FPS
+

--- a/originals/i.yaml
+++ b/originals/i.yaml
@@ -1,40 +1,74 @@
 - name: Icewind Dale
+  external:
+    wikipedia: Icewind Dale
   meta:
-    genre: [RPG]
-
-- name: "Icewind Dale: Heart of Winter"
-  meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
 - name: Icewind Dale II
+  external:
+    wikipedia: Icewind Dale II
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
-- name: [Imperialism, Imperialism (video game)]
+- name: 'Icewind Dale: Heart of Winter'
+  external:
+    wikipedia: 'Icewind Dale: Heart of Winter'
   meta:
-    genre: [TBS]
+    genre:
+    - RPG
+
+- name: Imperialism
+  external:
+    wikipedia: Imperialism (video game)
+  meta:
+    genre:
+    - TBS
 
 - name: Imperium Galactica
+  external:
+    wikipedia: Imperium Galactica
   meta:
-    genre: [RTS]
+    genre:
+    - RTS
 
 - name: Incredible Toons
+  external:
+    wikipedia: Incredible Toons
   meta:
-    genre: [Puzzle, Simulation]
+    genre:
+    - Puzzle
+    - Simulation
 
 - name: Indiana Jones and his Desktop Adventures
+  external:
+    wikipedia: Indiana Jones and his Desktop Adventures
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
-- name: [Infinity Loop, 'http://loopgame.co']
+- name: Infinity Loop
+  external:
+    website: http://loopgame.co
   meta:
-    genre: [Puzzle]
+    genre:
+    - Puzzle
 
 - name: Interstate '76
+  external:
+    wikipedia: Interstate '76
   meta:
-    genre: [Action, Racing]
-    theme: [Post-Apocalyptic]
+    genre:
+    - Action
+    - Racing
+    theme:
+    - Post-Apocalyptic
 
 - name: Iron Seed
+  external:
+    wikipedia: Iron Seed
   meta:
-    genre: [RTS]
+    genre:
+    - RTS
+

--- a/originals/j.yaml
+++ b/originals/j.yaml
@@ -1,66 +1,125 @@
 - name: Jack in the Dark
+  external:
+    wikipedia: Jack in the Dark
   meta:
-    genre: [Action, Adventure]
-    theme: [Horror, Alternate Historical]
+    genre:
+    - Action
+    - Adventure
+    theme:
+    - Horror
+    - Alternate Historical
 
 - name: Jade Empire
+  external:
+    wikipedia: Jade Empire
   meta:
-    genre: [RPG]
-    theme: [Martial Arts]
+    genre:
+    - RPG
+    theme:
+    - Martial Arts
 
 - name: Jagged Alliance 2
+  external:
+    wikipedia: Jagged Alliance 2
   meta:
-    genre: [RPG, Strategy, Turn-Based Tactics]
-    theme: [Sci-Fi, Modern Military]
+    genre:
+    - RPG
+    - Strategy
+    - Turn-Based Tactics
+    theme:
+    - Sci-Fi
+    - Modern Military
 
 - name: Jazz Jackrabbit
+  external:
+    wikipedia: Jazz Jackrabbit
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
 
 - name: Jazz Jackrabbit 2
+  external:
+    wikipedia: Jazz Jackrabbit 2
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
 
 - name: 'Jedi Knight II: Jedi Outcast'
+  external:
+    wikipedia: 'Jedi Knight II: Jedi Outcast'
   meta:
-    genre: [FPS, TPS]
+    genre:
+    - FPS
+    - TPS
 
 - name: 'Jedi Knight: Jedi Academy'
+  external:
+    wikipedia: 'Jedi Knight: Jedi Academy'
   meta:
-    genre: [FPS, TPS]
+    genre:
+    - FPS
+    - TPS
 
 - name: Jet-Story
+  external:
+    wikipedia: Jet-Story
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
 
 - name: Jetpac
+  external:
+    wikipedia: Jetpac
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
-- name: [Jewel Thief, 'http://www.mobygames.com/game/win3x/jewel-thief']
+- name: Jewel Thief
+  external:
+    website: http://www.mobygames.com/game/win3x/jewel-thief
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
 - name: JezzBall
+  external:
+    wikipedia: JezzBall
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
-- name: [Joust, Joust (video game)]
+- name: Joust
+  external:
+    wikipedia: Joust (video game)
   meta:
-    genre: [Arcade]
-
-- name: 'Jumpgate: The Reconstruction Initiative'
-  meta:
-    genre: [MMORPG]
+    genre:
+    - Arcade
 
 - name: Jump 'n Bump
+  external:
+    wikipedia: Jump 'n Bump
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
 
-- name: [Jumping Jack, Jumping Jack (Arcade game)]
+- name: 'Jumpgate: The Reconstruction Initiative'
+  external:
+    wikipedia: 'Jumpgate: The Reconstruction Initiative'
   meta:
-    genre: [Arcade]
+    genre:
+    - MMORPG
+
+- name: Jumping Jack
+  external:
+    wikipedia: Jumping Jack (Arcade game)
+  meta:
+    genre:
+    - Arcade
 
 - name: Jumpman
+  external:
+    wikipedia: Jumpman
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
+

--- a/originals/k.yaml
+++ b/originals/k.yaml
@@ -1,25 +1,46 @@
-
-- name: [Kaboom!, Kaboom! (video game)]
+- name: Kaboom!
+  external:
+    wikipedia: Kaboom! (video game)
   meta:
-    genre: [Arcade]
-
-- name: [Kid Chameleon, Kid Chameleon (video game)]
-  meta:
-    genre: [Platform]
-
-- name: [Knights, Knights (video game)]
-  meta:
-    genre: [Arcade]
-
-- name: Knights and Merchants
-  meta:
-    genre: [RTS]
-
-- name: Kula World
-  names: [Roll Away, Kula Quest]
-  meta:
-    genre: [Platform, Puzzle]
+    genre:
+    - Arcade
 
 - name: Ken's Labyrinth
+  external:
+    wikipedia: Ken's Labyrinth
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
+
+- name: Kid Chameleon
+  external:
+    wikipedia: Kid Chameleon (video game)
+  meta:
+    genre:
+    - Platform
+
+- name: Knights
+  external:
+    wikipedia: Knights (video game)
+  meta:
+    genre:
+    - Arcade
+
+- name: Knights and Merchants
+  external:
+    wikipedia: Knights and Merchants
+  meta:
+    genre:
+    - RTS
+
+- name: Kula World
+  external:
+    wikipedia: Kula World
+  meta:
+    genre:
+    - Platform
+    - Puzzle
+  names:
+  - Roll Away
+  - Kula Quest
+

--- a/originals/l.yaml
+++ b/originals/l.yaml
@@ -1,74 +1,133 @@
-
-- name: [Ladder, Ladder (video game)]
+- name: Ladder
+  external:
+    wikipedia: Ladder (video game)
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
-- name: [Larn, Larn (video game)]
+- name: Larn
+  external:
+    wikipedia: Larn (video game)
   meta:
-    genre: [Roguelike]
-
-- name: [Legion, 'http://www.mobygames.com/game/legion__']
-  meta:
-    genre: [Adventure]
-
-- name: [Lego Rock Raiders, Lego Rock Raiders (video game)]
-  meta:
-    genre: [RTS]
-
-- name: Liero
-  meta:
-    genre: [Platform, Shmup]
-
-- name: [Lionheart, Lionheart (video game)]
-  meta:
-    genre: [RPG, Action]
-
-- name: Little Big Adventure
-  meta:
-    genre: [Adventure]
-
-- name: [Locomotion (Amiga 1992), 'http://www.mobygames.com/game/locomotion']
-  meta:
-    genre: [Arcade, Puzzle]
-
-- name: Lode Runner
-  meta:
-    genre: [Arcade]
-
-- name: [Log!cal, 'http://hol.abime.net/906']
-  meta:
-    genre: [Puzzle]
-
-- name: [Lose Your Marbles, Sega Puzzle Pack]
-  meta:
-    genre: [Puzzle]
-
-- name: Lumines
-  meta:
-    genre: [Puzzle]
-
-- name: ['Lugaru: The Rabbit''s Foot', Lugaru]
-  meta:
-    genre: [Action]
-
-- name: [Legend of Zelda - A Link to the Past, 'The Legend of Zelda: A Link to the
-      Past']
-  meta:
-    genre: [Action, Adventure]
-
-- name: [Lemmings, Lemmings (video game)]
-  meta:
-    genre: [Puzzle]
-
-- name: [Lotus Esprit Turbo Challenge, Lotus (series)]
-  meta:
-    genre: [Racing]
+    genre:
+    - Roguelike
 
 - name: Legend of Zelda
+  external:
+    wikipedia: Legend of Zelda
   meta:
-    genre: [Action, Adventure]
+    genre:
+    - Action
+    - Adventure
+
+- name: Legend of Zelda - A Link to the Past
+  external:
+    wikipedia: 'The Legend of Zelda: A Link to the Past'
+  meta:
+    genre:
+    - Action
+    - Adventure
+
+- name: Legion
+  external:
+    website: http://www.mobygames.com/game/legion__
+  meta:
+    genre:
+    - Adventure
+
+- name: Lego Rock Raiders
+  external:
+    wikipedia: Lego Rock Raiders (video game)
+  meta:
+    genre:
+    - RTS
+
+- name: Lemmings
+  external:
+    wikipedia: Lemmings (video game)
+  meta:
+    genre:
+    - Puzzle
+
+- name: Liero
+  external:
+    wikipedia: Liero
+  meta:
+    genre:
+    - Platform
+    - Shmup
+
+- name: Lionheart
+  external:
+    wikipedia: Lionheart (video game)
+  meta:
+    genre:
+    - RPG
+    - Action
+
+- name: Little Big Adventure
+  external:
+    wikipedia: Little Big Adventure
+  meta:
+    genre:
+    - Adventure
 
 - name: Little Fighter 2
-  names: [LF2]
+  external:
+    wikipedia: Little Fighter 2
   meta:
-    genre: [Fighting]
+    genre:
+    - Fighting
+  names:
+  - LF2
+
+- name: Locomotion (Amiga 1992)
+  external:
+    website: http://www.mobygames.com/game/locomotion
+  meta:
+    genre:
+    - Arcade
+    - Puzzle
+
+- name: Lode Runner
+  external:
+    wikipedia: Lode Runner
+  meta:
+    genre:
+    - Arcade
+
+- name: Log!cal
+  external:
+    website: http://hol.abime.net/906
+  meta:
+    genre:
+    - Puzzle
+
+- name: Lose Your Marbles
+  external:
+    wikipedia: Sega Puzzle Pack
+  meta:
+    genre:
+    - Puzzle
+
+- name: Lotus Esprit Turbo Challenge
+  external:
+    wikipedia: Lotus (series)
+  meta:
+    genre:
+    - Racing
+
+- name: 'Lugaru: The Rabbit''s Foot'
+  external:
+    wikipedia: Lugaru
+  meta:
+    genre:
+    - Action
+
+- name: Lumines
+  external:
+    wikipedia: Lumines
+  meta:
+    genre:
+    - Puzzle
+

--- a/originals/m.yaml
+++ b/originals/m.yaml
@@ -1,176 +1,326 @@
-- name: 'Mafia: The City of Lost Heaven'
+- name: M.A.X.
+  external:
+    wikipedia: Mechanized Assault & Exploration
   meta:
-    genre: [Action, Adventure]
-    theme: [Crime]
-
-- name: Magical Drop
-  names: ["\u30DE\u30B8\u30AB\u30EB\u30C9\u30ED\u30C3\u30D7", MagiDro, "\u30DE\u30B8\
-      \u30C9\u30ED"]
-  meta:
-    genre: [Puzzle]
-
-- name: Marble Madness
-  meta:
-    genre: [Arcade]
-
-- name: [Maxit, 'http://www.mobygames.com/game/dos/maxit']
-  meta:
-    genre: [Strategy, TBS]
-
-- name: Metroid Prime
-  meta:
-    genre: [FPS, Adventure]
-
-- name: Missile Command
-  meta:
-    genre: [Arcade]
-
-- name: [Mad TV, Mad TV (video game)]
-  meta:
-    genre: [Strategy, Simulation]
-    theme: [Management]
-
-- name: 'Medal of Honor: Allied Assault'
-  meta:
-    genre: [FPS]
-
-- name: Monty Mole
-  meta:
-    genre: [Platform]
-
-- name: Moonbase Commander
-  meta:
-    genre: [TBS]
-
-- name: Mortal Kombat
-  meta:
-    genre: [Fighting]
-    theme: [Fantasy]
+    genre:
+    - RTS
+    - TBS
 
 - name: M.U.L.E.
+  external:
+    wikipedia: M.U.L.E.
   meta:
-    genre: [TBS]
+    genre:
+    - TBS
 
-- name: [Magic Carpet, Magic Carpet (video game)]
+- name: Mad TV
+  external:
+    wikipedia: Mad TV (video game)
   meta:
-    genre: [FPS]
+    genre:
+    - Strategy
+    - Simulation
+    theme:
+    - Management
+
+- name: 'Mafia: The City of Lost Heaven'
+  external:
+    wikipedia: 'Mafia: The City of Lost Heaven'
+  meta:
+    genre:
+    - Action
+    - Adventure
+    theme:
+    - Crime
+
+- name: Magic Carpet
+  external:
+    wikipedia: Magic Carpet (video game)
+  meta:
+    genre:
+    - FPS
 
 - name: 'Magic: The Gathering Online'
+  external:
+    wikipedia: 'Magic: The Gathering Online'
   meta:
-    genre: [Strategy, TBS]
-    subgenre: [Card Game]
-    theme: [Fantasy]
+    genre:
+    - Strategy
+    - TBS
+    subgenre:
+    - Card Game
+    theme:
+    - Fantasy
+
+- name: Magical Drop
+  external:
+    wikipedia: Magical Drop
+  meta:
+    genre:
+    - Puzzle
+  names:
+  - "\u30DE\u30B8\u30AB\u30EB\u30C9\u30ED\u30C3\u30D7"
+  - MagiDro
+  - "\u30DE\u30B8\u30C9\u30ED"
 
 - name: Manic Miner
+  external:
+    wikipedia: Manic Miner
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
 
-- name: [Marathon, Marathon_(video_game)]
+- name: Marathon
+  external:
+    wikipedia: Marathon_(video_game)
   meta:
-    genre: [FPS]
-    theme: [Sci-Fi]
+    genre:
+    - FPS
+    theme:
+    - Sci-Fi
 
 - name: Marathon 2
+  external:
+    wikipedia: Marathon 2
   meta:
-    genre: [FPS]
-    theme: [Sci-Fi]
+    genre:
+    - FPS
+    theme:
+    - Sci-Fi
 
 - name: Marathon Infinity
+  external:
+    wikipedia: Marathon Infinity
   meta:
-    genre: [FPS]
-    theme: [Sci-Fi]
+    genre:
+    - FPS
+    theme:
+    - Sci-Fi
 
-- name: Mario World
+- name: Marble Madness
+  external:
+    wikipedia: Marble Madness
   meta:
-    genre: [Platform]
-
-- name: Master of Monsters
-  meta:
-    genre: [TBS]
-    theme: [Fantasy]
-
-- name: [M.A.X., Mechanized Assault & Exploration]
-  meta:
-    genre: [RTS, TBS]
-
-- name: MechWarrior
-  meta:
-    genre: [Simulation, FPS]
-    subgenre: [Vehicular Combat]
-    theme: [Sci-Fi, Management]
-
-- name: MechCommander 2
-  meta:
-    genre: [RTS]
-
-- name: Mega Lo Mania
-  meta:
-    genre: [RTS]
-
-- name: [MegaMan, MegaMan (video game)]
-  meta:
-    genre: [Platform]
-
-- name: Meridian 59
-  meta:
-    genre: [RPG]
-
-- name: [Mice Men, 'https://dosgamer.com/mice-men/']
-  meta:
-    genre: [Puzzle]
-
-- name: [Millipede, Millipede (video game)]
-  meta:
-    genre: [Arcade]
-
-- name: Minecraft
-  meta:
-    genre: [Action, FPS]
-    subgenre: [Survival, Sandbox]
-    theme: [Fantasy]
-
-- name: [Minesweeper, Minesweeper (video game)]
-  meta:
-    genre: [Puzzle]
-
-- name: [Movie Business, 'http://www.gamebase64.com/game.php?id=14674&d=18']
-  meta:
-    genre: [Strategy, TBS]
-    theme: [Management]
+    genre:
+    - Arcade
 
 - name: Mario Kart
+  external:
+    wikipedia: Mario Kart
   meta:
-    genre: [Racing]
+    genre:
+    - Racing
+
+- name: Mario World
+  external:
+    wikipedia: Mario World
+  meta:
+    genre:
+    - Platform
+
+- name: Master of Monsters
+  external:
+    wikipedia: Master of Monsters
+  meta:
+    genre:
+    - TBS
+    theme:
+    - Fantasy
 
 - name: Master of Orion
+  external:
+    wikipedia: Master of Orion
   meta:
-    genre: [TBS]
-    subgenre: [4X]
-    theme: [Sci-Fi]
+    genre:
+    - TBS
+    subgenre:
+    - 4X
+    theme:
+    - Sci-Fi
 
 - name: Master of Orion 2
+  external:
+    wikipedia: Master of Orion 2
   meta:
-    genre: [TBS]
-    subgenre: [4X]
-    theme: [Sci-Fi]
+    genre:
+    - TBS
+    subgenre:
+    - 4X
+    theme:
+    - Sci-Fi
 
-- name: [Micro Machines, Micro Machines (video game series)]
+- name: Maxit
+  external:
+    website: http://www.mobygames.com/game/dos/maxit
   meta:
-    genre: [Racing]
+    genre:
+    - Strategy
+    - TBS
+
+- name: MechCommander 2
+  external:
+    wikipedia: MechCommander 2
+  meta:
+    genre:
+    - RTS
+
+- name: MechWarrior
+  external:
+    wikipedia: MechWarrior
+  meta:
+    genre:
+    - Simulation
+    - FPS
+    subgenre:
+    - Vehicular Combat
+    theme:
+    - Sci-Fi
+    - Management
+
+- name: 'Medal of Honor: Allied Assault'
+  external:
+    wikipedia: 'Medal of Honor: Allied Assault'
+  meta:
+    genre:
+    - FPS
+
+- name: Mega Lo Mania
+  external:
+    wikipedia: Mega Lo Mania
+  meta:
+    genre:
+    - RTS
+
+- name: MegaMan
+  external:
+    wikipedia: MegaMan (video game)
+  meta:
+    genre:
+    - Platform
+
+- name: Meridian 59
+  external:
+    wikipedia: Meridian 59
+  meta:
+    genre:
+    - RPG
+
+- name: Metroid Prime
+  external:
+    wikipedia: Metroid Prime
+  meta:
+    genre:
+    - FPS
+    - Adventure
+
+- name: Mice Men
+  external:
+    website: https://dosgamer.com/mice-men/
+  meta:
+    genre:
+    - Puzzle
+
+- name: Micro Machines
+  external:
+    wikipedia: Micro Machines (video game series)
+  meta:
+    genre:
+    - Racing
 
 - name: Microsoft Flight Simulator
+  external:
+    wikipedia: Microsoft Flight Simulator
   meta:
-    genre: [Simulation]
+    genre:
+    - Simulation
 
 - name: Microsoft Train Simulator
+  external:
+    wikipedia: Microsoft Train Simulator
   meta:
-    genre: [Simulation]
+    genre:
+    - Simulation
 
 - name: Midnight Club II
-  names: [Midnight Club 2]
+  external:
+    wikipedia: Midnight Club II
   meta:
-    genre: [Racing]
+    genre:
+    - Racing
+  names:
+  - Midnight Club 2
+
+- name: Millipede
+  external:
+    wikipedia: Millipede (video game)
+  meta:
+    genre:
+    - Arcade
+
+- name: Minecraft
+  external:
+    wikipedia: Minecraft
+  meta:
+    genre:
+    - Action
+    - FPS
+    subgenre:
+    - Survival
+    - Sandbox
+    theme:
+    - Fantasy
+
+- name: Minesweeper
+  external:
+    wikipedia: Minesweeper (video game)
+  meta:
+    genre:
+    - Puzzle
+
+- name: Missile Command
+  external:
+    wikipedia: Missile Command
+  meta:
+    genre:
+    - Arcade
+
+- name: Monty Mole
+  external:
+    wikipedia: Monty Mole
+  meta:
+    genre:
+    - Platform
+
+- name: Moonbase Commander
+  external:
+    wikipedia: Moonbase Commander
+  meta:
+    genre:
+    - TBS
+
+- name: Mortal Kombat
+  external:
+    wikipedia: Mortal Kombat
+  meta:
+    genre:
+    - Fighting
+    theme:
+    - Fantasy
+
+- name: Movie Business
+  external:
+    website: http://www.gamebase64.com/game.php?id=14674&d=18
+  meta:
+    genre:
+    - Strategy
+    - TBS
+    theme:
+    - Management
 
 - name: 'Myst III: Exile'
+  external:
+    wikipedia: 'Myst III: Exile'
   meta:
-    genre: [Adventure]
+    genre:
+    - Adventure
+

--- a/originals/n.yaml
+++ b/originals/n.yaml
@@ -1,47 +1,83 @@
-
-- name: [Natural Selection, Natural Selection (video game)]
+- name: Natural Selection
+  external:
+    wikipedia: Natural Selection (video game)
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
+
+- name: Nebulus
+  external:
+    wikipedia: Nebulus (video game)
+  meta:
+    genre:
+    - Arcade
 
 - name: Need For Speed II SE
+  external:
+    wikipedia: Need For Speed II SE
   meta:
-    genre: [Racing]
-
-- name: [Night Stalker, Night Stalker (video game)]
-  meta:
-    genre: [Arcade]
-
-- name: [Nebulus, Nebulus (video game)]
-  meta:
-    genre: [Arcade]
+    genre:
+    - Racing
 
 - name: NetHack
+  external:
+    wikipedia: NetHack
   meta:
-    genre: [Roguelike]
+    genre:
+    - Roguelike
 
 - name: Nether Earth
+  external:
+    wikipedia: Nether Earth
   meta:
-    genre: [RTS]
+    genre:
+    - RTS
 
 - name: Neverwinter Nights
+  external:
+    wikipedia: Neverwinter Nights
   meta:
-    genre: [RPG]
-    theme: [Fantasy]
+    genre:
+    - RPG
+    theme:
+    - Fantasy
 
 - name: Neverwinter Nights 2
+  external:
+    wikipedia: Neverwinter Nights 2
   meta:
-    genre: [RPG]
-    theme: [Fantasy]
+    genre:
+    - RPG
+    theme:
+    - Fantasy
 
 - name: Nexuiz
+  external:
+    wikipedia: Nexuiz
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
+
+- name: Night Stalker
+  external:
+    wikipedia: Night Stalker (video game)
+  meta:
+    genre:
+    - Arcade
 
 - name: Nodes of Yesod
+  external:
+    wikipedia: Nodes of Yesod
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
 
 - name: Nuclear Reaction
-  platform: [Amiga]
+  external:
+    wikipedia: Nuclear Reaction
   meta:
-    genre: [Puzzle]
+    genre:
+    - Puzzle
+  platform:
+  - Amiga
+

--- a/originals/o.yaml
+++ b/originals/o.yaml
@@ -1,42 +1,79 @@
-
-- name: [Octopus, List of Game & Watch games#Octopus]
+- name: Octopus
+  external:
+    wikipedia: List of Game & Watch games#Octopus
   meta:
-    genre: [Arcade]
-
-- name: 'Oddworld: Abe''s Oddysee'
-  meta:
-    genre: [Platform, Adventure]
+    genre:
+    - Arcade
 
 - name: 'Oddworld: Abe''s Exoddus'
+  external:
+    wikipedia: 'Oddworld: Abe''s Exoddus'
   meta:
-    genre: [Platform, Adventure]
+    genre:
+    - Platform
+    - Adventure
 
-- name: [Outcast, Outcast (video game)]
+- name: 'Oddworld: Abe''s Oddysee'
+  external:
+    wikipedia: 'Oddworld: Abe''s Oddysee'
   meta:
-    genre: [Adventure, Action]
-
-- name: [Outlaws, Outlaws (1997 video game)]
-  meta:
-    genre: [FPS]
-
-- name: Outrun
-  names: ["\u30A2\u30A6\u30C8 \u30E9\u30F3", Auto Ran]
-  meta:
-    genre: [Arcade, Racing]
-
-- name: Oxyd
-  meta:
-    genre: [Puzzle]
-
-- name: 'One Must Fall: 2097'
-  meta:
-    genre: [Fighting]
-    theme: [Sci-Fi]
-
-- name: [Overflow, 'http://amigagamer.blogspot.co.uk/2012/11/overflow-amiga-pipemania-clone.html']
-  meta:
-    genre: [Puzzle]
+    genre:
+    - Platform
+    - Adventure
 
 - name: Omega Race
+  external:
+    wikipedia: Omega Race
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
+
+- name: 'One Must Fall: 2097'
+  external:
+    wikipedia: 'One Must Fall: 2097'
+  meta:
+    genre:
+    - Fighting
+    theme:
+    - Sci-Fi
+
+- name: Outcast
+  external:
+    wikipedia: Outcast (video game)
+  meta:
+    genre:
+    - Adventure
+    - Action
+
+- name: Outlaws
+  external:
+    wikipedia: Outlaws (1997 video game)
+  meta:
+    genre:
+    - FPS
+
+- name: Outrun
+  external:
+    wikipedia: Outrun
+  meta:
+    genre:
+    - Arcade
+    - Racing
+  names:
+  - "\u30A2\u30A6\u30C8 \u30E9\u30F3"
+  - Auto Ran
+
+- name: Overflow
+  external:
+    website: http://amigagamer.blogspot.co.uk/2012/11/overflow-amiga-pipemania-clone.html
+  meta:
+    genre:
+    - Puzzle
+
+- name: Oxyd
+  external:
+    wikipedia: Oxyd
+  meta:
+    genre:
+    - Puzzle
+

--- a/originals/p.yaml
+++ b/originals/p.yaml
@@ -1,84 +1,159 @@
 - name: Pac-Man
+  external:
+    wikipedia: Pac-Man
   meta:
-    genre: [Arcade]
-
-- name: Pitfall!
-  meta:
-    genre: [Arcade, Platform]
-
-- name: "Planescape: Torment"
-  meta:
-    genre: [RPG]
-
-- name: 'Populous: The Beginning'
-  meta:
-    genre: [RTS]
-
-- name: [Portal, Portal (video game)]
-  meta:
-    genre: [FPS, Puzzle]
-
-- name: Prince of Persia
-  meta:
-    genre: [Platform]
+    genre:
+    - Arcade
 
 - name: Panzer General
+  external:
+    wikipedia: Panzer General
   meta:
-    genre: [TBS]
-
-- name: [Paratrooper, Paratrooper (video game)]
-  meta:
-    genre: [Arcade]
-
-- name: [Phantasy, Phantasy Star (video game)]
-  meta:
-    genre: [RPG]
-
-- name: Pipe Mania
-  meta:
-    genre: [Puzzle]
-
-- name: ["Pok\xE9mon", "Pok\xE9mon (video game series)"]
-  meta:
-    genre: [RPG]
-
-- name: "Pok\xE9mon Mystery Dungeon"
-  meta:
-    genre: [RPG]
-
-- name: [Pole Position, Pole Position (video game)]
-  meta:
-    genre: [Sports, Racing]
-    theme: [Motorsports]
-
-- name: Progress Quest
-  meta:
-    genre: [MMORPG]
-    theme: [Comedy]
-
-- name: [Punch-Out!!, Punch-Out!! (arcade game)]
-  meta:
-    genre: [Fighting, Sports]
-    subgenre: [Boxing]
-    theme: [Comedy]
-
-- name: [Pushover, Pushover (video game)]
-  meta:
-    genre: [Platform, Puzzle]
-
-- name: [Puzznic / Brix, Brix (video game)]
-  meta:
-    genre: [Puzzle, Arcade]
+    genre:
+    - TBS
 
 - name: Paradroid
+  external:
+    wikipedia: Paradroid
   meta:
-    genre: [Shmup, Puzzle]
-    theme: [Fantasy, Sci-Fi]
+    genre:
+    - Shmup
+    - Puzzle
+    theme:
+    - Fantasy
+    - Sci-Fi
+
+- name: Paratrooper
+  external:
+    wikipedia: Paratrooper (video game)
+  meta:
+    genre:
+    - Arcade
+
+- name: Phantasy
+  external:
+    wikipedia: Phantasy Star (video game)
+  meta:
+    genre:
+    - RPG
+
+- name: Pipe Mania
+  external:
+    wikipedia: Pipe Mania
+  meta:
+    genre:
+    - Puzzle
+
+- name: Pitfall!
+  external:
+    wikipedia: Pitfall!
+  meta:
+    genre:
+    - Arcade
+    - Platform
 
 - name: Pizza Tycoon
+  external:
+    wikipedia: Pizza Tycoon
   meta:
-    genre: [Simulation]
+    genre:
+    - Simulation
+
+- name: 'Planescape: Torment'
+  external:
+    wikipedia: 'Planescape: Torment'
+  meta:
+    genre:
+    - RPG
+
+- name: "Pok\xE9mon"
+  external:
+    wikipedia: "Pok\xE9mon (video game series)"
+  meta:
+    genre:
+    - RPG
+
+- name: "Pok\xE9mon Mystery Dungeon"
+  external:
+    wikipedia: "Pok\xE9mon Mystery Dungeon"
+  meta:
+    genre:
+    - RPG
+
+- name: Pole Position
+  external:
+    wikipedia: Pole Position (video game)
+  meta:
+    genre:
+    - Sports
+    - Racing
+    theme:
+    - Motorsports
+
+- name: 'Populous: The Beginning'
+  external:
+    wikipedia: 'Populous: The Beginning'
+  meta:
+    genre:
+    - RTS
+
+- name: Portal
+  external:
+    wikipedia: Portal (video game)
+  meta:
+    genre:
+    - FPS
+    - Puzzle
+
+- name: Prince of Persia
+  external:
+    wikipedia: Prince of Persia
+  meta:
+    genre:
+    - Platform
+
+- name: Progress Quest
+  external:
+    wikipedia: Progress Quest
+  meta:
+    genre:
+    - MMORPG
+    theme:
+    - Comedy
+
+- name: Punch-Out!!
+  external:
+    wikipedia: Punch-Out!! (arcade game)
+  meta:
+    genre:
+    - Fighting
+    - Sports
+    subgenre:
+    - Boxing
+    theme:
+    - Comedy
+
+- name: Pushover
+  external:
+    wikipedia: Pushover (video game)
+  meta:
+    genre:
+    - Platform
+    - Puzzle
 
 - name: Puzzle Bobble
+  external:
+    wikipedia: Puzzle Bobble
   meta:
-    genre: [Puzzle, Arcade]
+    genre:
+    - Puzzle
+    - Arcade
+
+- name: Puzznic / Brix
+  external:
+    wikipedia: Brix (video game)
+  meta:
+    genre:
+    - Puzzle
+    - Arcade
+

--- a/originals/q.yaml
+++ b/originals/q.yaml
@@ -1,20 +1,35 @@
-
-- name: [Quadnet, 'https://www.mobygames.com/game/dos/quadnet']
+- name: Q*bert
+  external:
+    wikipedia: Q*bert
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
+
+- name: Quadnet
+  external:
+    website: https://www.mobygames.com/game/dos/quadnet
+  meta:
+    genre:
+    - Arcade
 
 - name: Quake
+  external:
+    wikipedia: Quake
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
 
 - name: Quake 2
+  external:
+    wikipedia: Quake 2
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
 
 - name: Quake 3
+  external:
+    wikipedia: Quake 3
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
 
-- name: Q*bert
-  meta:
-    genre: [Arcade]

--- a/originals/r.yaml
+++ b/originals/r.yaml
@@ -1,80 +1,151 @@
-
 - name: R-Type
+  external:
+    wikipedia: R-Type
   meta:
-    genre: [Shmup]
+    genre:
+    - Shmup
 
 - name: Railroad Tycoon
+  external:
+    wikipedia: Railroad Tycoon
   meta:
-    genre: [Simulation, Strategy]
-    theme: [Management]
+    genre:
+    - Simulation
+    - Strategy
+    theme:
+    - Management
 
-- name: [Rampart, Rampart (video game)]
+- name: Rampart
+  external:
+    wikipedia: Rampart (video game)
   meta:
-    genre: [Shmup, Puzzle]
+    genre:
+    - Shmup
+    - Puzzle
 
 - name: 'Raptor: Call of the Shadows'
+  external:
+    wikipedia: 'Raptor: Call of the Shadows'
   meta:
-    genre: [Shmup]
+    genre:
+    - Shmup
 
 - name: Redneck Rampage
+  external:
+    wikipedia: Redneck Rampage
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
 
 - name: Rescue!
+  external:
+    wikipedia: Rescue!
   meta:
-    genre: [Action, Adventure]
+    genre:
+    - Action
+    - Adventure
 
 - name: 'Return of the Incredible Machine: Contraptions'
+  external:
+    wikipedia: 'Return of the Incredible Machine: Contraptions'
   meta:
-    genre: [Puzzle, Simulation]
+    genre:
+    - Puzzle
+    - Simulation
 
 - name: Rick Dangerous
+  external:
+    wikipedia: Rick Dangerous
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
 
 - name: Rise of the Triad
+  external:
+    wikipedia: Rise of the Triad
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
 
 - name: River Raid
+  external:
+    wikipedia: River Raid
   meta:
-    genre: [Shmup]
+    genre:
+    - Shmup
 
 - name: Road Fighter
+  external:
+    wikipedia: Road Fighter
   meta:
-    genre: [Racing, Arcade]
+    genre:
+    - Racing
+    - Arcade
 
 - name: Robotfindskitten
+  external:
+    wikipedia: Robotfindskitten
   meta:
-    genre: [Adventure, Roguelike]
-    theme: [Sci-Fi, Meditative, Comedy]
+    genre:
+    - Adventure
+    - Roguelike
+    theme:
+    - Sci-Fi
+    - Meditative
+    - Comedy
 
 - name: 'Robotron: 2084'
+  external:
+    wikipedia: 'Robotron: 2084'
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
 - name: Rodent's Revenge
+  external:
+    wikipedia: Rodent's Revenge
   meta:
-    genre: [Puzzle]
+    genre:
+    - Puzzle
+
+- name: Rogue
+  external:
+    wikipedia: Rogue_(video_game)
+  meta:
+    genre:
+    - Roguelike
 
 - name: RollerCoaster Tycoon
+  external:
+    wikipedia: RollerCoaster Tycoon
   meta:
-    genre: [Simulation, Strategy]
-    theme: [Management]
+    genre:
+    - Simulation
+    - Strategy
+    theme:
+    - Management
 
 - name: RollerCoaster Tycoon 2
+  external:
+    wikipedia: RollerCoaster Tycoon 2
   meta:
-    genre: [Simulation, Strategy]
-    theme: [Management]
-
-- name: [Rogue, Rogue_(video_game)]
-  meta:
-    genre: [Roguelike]
-
-- name: Ryzom
-  meta:
-    genre: [MMORPG]
+    genre:
+    - Simulation
+    - Strategy
+    theme:
+    - Management
 
 - name: RPG Maker
+  external:
+    wikipedia: RPG Maker
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
+
+- name: Ryzom
+  external:
+    wikipedia: Ryzom
+  meta:
+    genre:
+    - MMORPG
+

--- a/originals/s.yaml
+++ b/originals/s.yaml
@@ -1,335 +1,631 @@
 - name: Scorched Earth
+  external:
+    wikipedia: Scorched Earth
   meta:
-    genre: [Turn-Based Tactics]
+    genre:
+    - Turn-Based Tactics
 
-- name: [Scramble, Scramble (video game)]
+- name: Scramble
+  external:
+    wikipedia: Scramble (video game)
   meta:
-    genre: [Arcade]
-
-- name: Seaquest
-  meta:
-    genre: [Arcade]
-
-- name: Skool Daze
-  meta:
-    genre: [Action, Adventure, Platform]
-
-- name: 'Space Rangers 2: Dominators'
-  meta:
-    genre: [RTS, Adventure, Shmup, RPG, TPS]
-
-- name: Strike Commander
-  meta:
-    genre: [Action, Simulation]
-    subgenre: [Flight Simulator]
-    theme: [Modern Military]
-
-- name: Strikers 1945
-  meta:
-    genre: [Shmup]
+    genre:
+    - Arcade
 
 - name: Sea Dragon
-  platform: [Apple II, Atari, Commodore 64, DOS]
+  external:
+    wikipedia: Sea Dragon
   meta:
-    genre: [Action, Shooter]
+    genre:
+    - Action
+    - Shooter
+  platform:
+  - Apple II
+  - Atari
+  - Commodore 64
+  - DOS
+
+- name: Seaquest
+  external:
+    wikipedia: Seaquest
+  meta:
+    genre:
+    - Arcade
 
 - name: Sensible Soccer
+  external:
+    wikipedia: Sensible Soccer
   meta:
-    genre: [Sports]
-    subgenre: [Soccer]
+    genre:
+    - Sports
+    subgenre:
+    - Soccer
 
-- name: [Sensitive, 'https://www.mobygames.com/game/c64/sensitive']
+- name: Sensitive
+  external:
+    website: https://www.mobygames.com/game/c64/sensitive
   meta:
-    genre: [Puzzle, Arcade]
+    genre:
+    - Puzzle
+    - Arcade
 
-- name: [Seven Kingdoms, Seven Kingdoms (computer game)]
+- name: Seven Kingdoms
+  external:
+    wikipedia: Seven Kingdoms (computer game)
   meta:
-    genre: [RTS]
-
-- name: 'Shadowgrounds: Survivor'
-  meta:
-    genre: [Shooter]
+    genre:
+    - RTS
 
 - name: Shadow of the Beast
+  external:
+    wikipedia: Shadow of the Beast
   meta:
-    genre: [Platform]
-
-- name: Shining Force II
-  meta:
-    genre: [RPG]
-
-- name: Shining Soul
-  meta:
-    genre: [Action, RPG]
-
-- name: Sid Meier's Alpha Centauri
-  meta:
-    genre: [TBS]
-
-- name: Sid Meier's Colonization
-  meta:
-    genre: [TBS]
-
-- name: Sid Meier's Pirates!
-  meta:
-    genre: [Action, Adventure, RTS]
+    genre:
+    - Platform
 
 - name: Shadow Warrior
+  external:
+    wikipedia: Shadow Warrior
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
+
+- name: 'Shadowgrounds: Survivor'
+  external:
+    wikipedia: 'Shadowgrounds: Survivor'
+  meta:
+    genre:
+    - Shooter
+
+- name: Shining Force II
+  external:
+    wikipedia: Shining Force II
+  meta:
+    genre:
+    - RPG
+
+- name: Shining Soul
+  external:
+    wikipedia: Shining Soul
+  meta:
+    genre:
+    - Action
+    - RPG
 
 - name: Ship Simulator 2006
+  external:
+    wikipedia: Ship Simulator 2006
   meta:
-    genre: [Simulation]
+    genre:
+    - Simulation
 
 - name: Ship Simulator 2008
+  external:
+    wikipedia: Ship Simulator 2008
   meta:
-    genre: [Simulation]
+    genre:
+    - Simulation
 
 - name: Ship Simulator Extremes
+  external:
+    wikipedia: Ship Simulator Extremes
   meta:
-    genre: [Simulation]
-
-- name: [Siege, Siege (video game)]
-  meta:
-    genre: [Puzzle, Arcade]
-
-- name: Siege of Avalon
-  meta:
-    genre: [Action, RPG]
-
-- name: [Silencer, Silencer (video game)]
-  meta:
-    genre: [Action]
-
-- name: Silent Hunter 4
-  meta:
-    genre: [Action, Simulation]
-    subgenre: [Submarine Simulator]
-    theme: [World War II]
-
-- name: SimCity 2000
-  meta:
-    genre: [Simulation]
-
-- name: SimCopter
-  meta:
-    genre: [Simulation]
-
-- name: [Simon, Simon (game)]
-  meta:
-    genre: [Arcade]
-
-- name: SimTower
-  meta:
-    genre: [Simulation, Strategy]
-    theme: [Management]
-
-- name: SingStar
-  meta:
-    genre: [Rhythm]
-
-- name: [Snipes, Snipes (video game)]
-
-- name: Solar Fox
-  meta:
-    genre: [Arcade]
-
-- name: 'Sonic Chronicles: The Dark Brotherhood'
-  meta:
-    genre: [RPG]
-
-- name: [Sopwith, Sopwith (video game)]
-  meta:
-    genre: [Arcade]
-
-- name: Space Invaders
-  meta:
-    genre: [Arcade]
-
-- name: [Space Rangers, Space Rangers (video game)]
-  meta:
-    genre: [TBS]
-
-- name: [Spear of Destiny, Spear of Destiny (video game)]
-  meta:
-    genre: [FPS]
-
-- name: Speedball 2
-  meta:
-    genre: [Action, Sports]
-    subgenre: [Handball, Hockey]
-    theme: [Sci-Fi, Cyberpunk]
-
-- name: Star Control 2
-  meta:
-    genre: [RTS]
-
-- name: "Star Trek: Voyager \u2013 Elite Force"
-  meta:
-    genre: [FPS]
-
-- name: Starcraft
-  meta:
-    genre: [RTS]
-
-- name: Stunt Car Racer
-  meta:
-    genre: [Racing]
-
-- name: Stars!
-  meta:
-    genre: [TBS]
-
-- name: Star Raiders
-  meta:
-    genre: [Action, Simulation]
-    theme: [Sci-Fi]
-
-- name: [Star Ruler 2, 'http://www.mobygames.com/game/star-ruler-2']
-  meta:
-    genre: [RTS]
-    subgenre: [4X]
-    theme: [Sci-Fi]
-
-- name: [Star Wars (1983 arcade game), Star Wars (1983 video game)]
-  meta:
-    genre: [Arcade]
-
-- name: 'Star Wars: Knights of the Old Republic'
-  meta:
-    genre: [RPG]
-    theme: [Sci-Fi]
-
-- name: "Star Wars: Knights of the Old Republic II \u2013 The Sith Lords"
-  meta:
-    genre: [RPG]
-    theme: [Sci-Fi]
-
-- name: 'Star Wars: Yoda Stories'
-  meta:
-    genre: [RPG]
-
-- name: Starshatter
-  meta:
-    genre: [Simulation]
-    subgenre: [Space Flight]
-    theme: [Sci-Fi]
-
-- name: [Stunts, Stunts (video game)]
-  names: [4D Sports Driving]
-  meta:
-    genre: [Racing]
-
-- name: [Styx, Styx (Spectrum video game)]
-  meta:
-    genre: [Arcade]
-
-- name: 'SunDog: Frozen Legacy'
-  meta:
-    genre: [RPG]
-    subgenre: [Space Flight]
-
-- name: Supaplex
-  meta:
-    genre: [Puzzle]
-
-- name: Super Cars
-  meta:
-    genre: [Racing]
-
-- name: Super Foul Egg
-  meta:
-    genre: [Puzzle, Arcade]
-
-- name: [Super Mario, Super Mario (series)]
-  meta:
-    genre: [Platform]
-
-- name: [Super Methane Brothers, Super Methane Bros.]
-  meta:
-    genre: [Platform, Arcade]
-
-- name: Super Monkey Ball
-  meta:
-    genre: [Arcade, Platform]
-
-- name: [Survivor (1986), Survivor (video game)]
-  meta:
-    genre: [Puzzle]
-
-- name: [Syndicate, Syndicate (video game)]
-  meta:
-    genre: [RTS]
-
-- name: Syndicate Wars
-  meta:
-    genre: [RTS]
-
-- name: System Shock
-  names: ['System Shock: Enhanced Edition']
-  platform: [DOS, Windows]
-  meta:
-    genre: [RPG, FPS]
+    genre:
+    - Simulation
 
 - name: Shobon Action
+  external:
+    wikipedia: Shobon Action
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
 
-- name: SkiFree
+- name: Sid Meier's Alpha Centauri
+  external:
+    wikipedia: Sid Meier's Alpha Centauri
   meta:
-    genre: [Arcade, Sports]
-    subgenre: [Skiing]
+    genre:
+    - TBS
 
-- name: Slot Racers
+- name: Sid Meier's Colonization
+  external:
+    wikipedia: Sid Meier's Colonization
   meta:
-    genre: [Arcade]
+    genre:
+    - TBS
 
-- name: [Snake, Snake (video game)]
+- name: Sid Meier's Pirates!
+  external:
+    wikipedia: Sid Meier's Pirates!
   meta:
-    genre: [Arcade]
+    genre:
+    - Action
+    - Adventure
+    - RTS
 
-- name: Space Station 13
+- name: Siege
+  external:
+    wikipedia: Siege (video game)
   meta:
-    genre: [RPG, Simulation]
-    theme: [Sci-Fi, Comedy, Espionage]
+    genre:
+    - Puzzle
+    - Arcade
 
-- name: Star Fox 64
+- name: Siege of Avalon
+  external:
+    wikipedia: Siege of Avalon
   meta:
-    genre: [Action, Flight, TPS]
-    theme: [Sci-Fi]
+    genre:
+    - Action
+    - RPG
 
-- name: [Story of Seasons series, Story of Seasons (series)]
-  names: [Harvest Moon]
+- name: Silencer
+  external:
+    wikipedia: Silencer (video game)
   meta:
-    genre: [Simulation]
-    theme: [Anime]
+    genre:
+    - Action
 
-- name: ['Stratosphere: Conquest of the Skies', 'http://www.mobygames.com/game/windows/stratosphere-conquest-of-the-skies']
+- name: Silent Hunter 4
+  external:
+    wikipedia: Silent Hunter 4
   meta:
-    genre: [RTS, TPS]
-
-- name: [Swing, Swing (video game)]
-  meta:
-    genre: [Puzzle, Arcade]
+    genre:
+    - Action
+    - Simulation
+    subgenre:
+    - Submarine Simulator
+    theme:
+    - World War II
 
 - name: Simcity
+  external:
+    wikipedia: Simcity
   meta:
-    genre: [Simulation]
-    theme: [Management]
+    genre:
+    - Simulation
+    theme:
+    - Management
+
+- name: SimCity 2000
+  external:
+    wikipedia: SimCity 2000
+  meta:
+    genre:
+    - Simulation
+
+- name: SimCopter
+  external:
+    wikipedia: SimCopter
+  meta:
+    genre:
+    - Simulation
+
+- name: Simon
+  external:
+    wikipedia: Simon (game)
+  meta:
+    genre:
+    - Arcade
+
+- name: SimTower
+  external:
+    wikipedia: SimTower
+  meta:
+    genre:
+    - Simulation
+    - Strategy
+    theme:
+    - Management
+
+- name: SingStar
+  external:
+    wikipedia: SingStar
+  meta:
+    genre:
+    - Rhythm
+
+- name: SkiFree
+  external:
+    wikipedia: SkiFree
+  meta:
+    genre:
+    - Arcade
+    - Sports
+    subgenre:
+    - Skiing
+
+- name: Skool Daze
+  external:
+    wikipedia: Skool Daze
+  meta:
+    genre:
+    - Action
+    - Adventure
+    - Platform
+
+- name: SkyRoads
+  external:
+    wikipedia: SkyRoads (video game)
+  meta:
+    genre:
+    - Platform
+
+- name: Slot Racers
+  external:
+    wikipedia: Slot Racers
+  meta:
+    genre:
+    - Arcade
+
+- name: Snake
+  external:
+    wikipedia: Snake (video game)
+  meta:
+    genre:
+    - Arcade
+
+- name: Snipes
+  external:
+    wikipedia: Snipes (video game)
 
 - name: Sokoban
+  external:
+    wikipedia: Sokoban
   meta:
-    genre: [Puzzle]
+    genre:
+    - Puzzle
+
+- name: Solar Fox
+  external:
+    wikipedia: Solar Fox
+  meta:
+    genre:
+    - Arcade
+
+- name: 'Sonic Chronicles: The Dark Brotherhood'
+  external:
+    wikipedia: 'Sonic Chronicles: The Dark Brotherhood'
+  meta:
+    genre:
+    - RPG
 
 - name: Sonic the Hedgehog
+  external:
+    wikipedia: Sonic the Hedgehog
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
+
+- name: Sopwith
+  external:
+    wikipedia: Sopwith (video game)
+  meta:
+    genre:
+    - Arcade
+
+- name: Space Invaders
+  external:
+    wikipedia: Space Invaders
+  meta:
+    genre:
+    - Arcade
+
+- name: Space Rangers
+  external:
+    wikipedia: Space Rangers (video game)
+  meta:
+    genre:
+    - TBS
+
+- name: 'Space Rangers 2: Dominators'
+  external:
+    wikipedia: 'Space Rangers 2: Dominators'
+  meta:
+    genre:
+    - RTS
+    - Adventure
+    - Shmup
+    - RPG
+    - TPS
+
+- name: Space Station 13
+  external:
+    wikipedia: Space Station 13
+  meta:
+    genre:
+    - RPG
+    - Simulation
+    theme:
+    - Sci-Fi
+    - Comedy
+    - Espionage
+
+- name: Spear of Destiny
+  external:
+    wikipedia: Spear of Destiny (video game)
+  meta:
+    genre:
+    - FPS
+
+- name: Speedball 2
+  external:
+    wikipedia: Speedball 2
+  meta:
+    genre:
+    - Action
+    - Sports
+    subgenre:
+    - Handball
+    - Hockey
+    theme:
+    - Sci-Fi
+    - Cyberpunk
+
+- name: Star Control 2
+  external:
+    wikipedia: Star Control 2
+  meta:
+    genre:
+    - RTS
+
+- name: Star Fox 64
+  external:
+    wikipedia: Star Fox 64
+  meta:
+    genre:
+    - Action
+    - Flight
+    - TPS
+    theme:
+    - Sci-Fi
+
+- name: Star Raiders
+  external:
+    wikipedia: Star Raiders
+  meta:
+    genre:
+    - Action
+    - Simulation
+    theme:
+    - Sci-Fi
+
+- name: Star Ruler 2
+  external:
+    website: http://www.mobygames.com/game/star-ruler-2
+  meta:
+    genre:
+    - RTS
+    subgenre:
+    - 4X
+    theme:
+    - Sci-Fi
+
+- name: "Star Trek: Voyager \u2013 Elite Force"
+  external:
+    wikipedia: "Star Trek: Voyager \u2013 Elite Force"
+  meta:
+    genre:
+    - FPS
+
+- name: Star Wars (1983 arcade game)
+  external:
+    wikipedia: Star Wars (1983 video game)
+  meta:
+    genre:
+    - Arcade
+
+- name: 'Star Wars: Knights of the Old Republic'
+  external:
+    wikipedia: 'Star Wars: Knights of the Old Republic'
+  meta:
+    genre:
+    - RPG
+    theme:
+    - Sci-Fi
+
+- name: "Star Wars: Knights of the Old Republic II \u2013 The Sith Lords"
+  external:
+    wikipedia: "Star Wars: Knights of the Old Republic II \u2013 The Sith Lords"
+  meta:
+    genre:
+    - RPG
+    theme:
+    - Sci-Fi
+
+- name: 'Star Wars: Yoda Stories'
+  external:
+    wikipedia: 'Star Wars: Yoda Stories'
+  meta:
+    genre:
+    - RPG
+
+- name: Starcraft
+  external:
+    wikipedia: Starcraft
+  meta:
+    genre:
+    - RTS
+
+- name: Stars!
+  external:
+    wikipedia: Stars!
+  meta:
+    genre:
+    - TBS
+
+- name: Starshatter
+  external:
+    wikipedia: Starshatter
+  meta:
+    genre:
+    - Simulation
+    subgenre:
+    - Space Flight
+    theme:
+    - Sci-Fi
+
+- name: Story of Seasons series
+  external:
+    wikipedia: Story of Seasons (series)
+  meta:
+    genre:
+    - Simulation
+    theme:
+    - Anime
+  names:
+  - Harvest Moon
+
+- name: 'Stratosphere: Conquest of the Skies'
+  external:
+    website: http://www.mobygames.com/game/windows/stratosphere-conquest-of-the-skies
+  meta:
+    genre:
+    - RTS
+    - TPS
+
+- name: Strike Commander
+  external:
+    wikipedia: Strike Commander
+  meta:
+    genre:
+    - Action
+    - Simulation
+    subgenre:
+    - Flight Simulator
+    theme:
+    - Modern Military
+
+- name: Strikers 1945
+  external:
+    wikipedia: Strikers 1945
+  meta:
+    genre:
+    - Shmup
+
+- name: Stunt Car Racer
+  external:
+    wikipedia: Stunt Car Racer
+  meta:
+    genre:
+    - Racing
+
+- name: Stunts
+  external:
+    wikipedia: Stunts (video game)
+  meta:
+    genre:
+    - Racing
+  names:
+  - 4D Sports Driving
+
+- name: Styx
+  external:
+    wikipedia: Styx (Spectrum video game)
+  meta:
+    genre:
+    - Arcade
+
+- name: 'SunDog: Frozen Legacy'
+  external:
+    wikipedia: 'SunDog: Frozen Legacy'
+  meta:
+    genre:
+    - RPG
+    subgenre:
+    - Space Flight
+
+- name: Supaplex
+  external:
+    wikipedia: Supaplex
+  meta:
+    genre:
+    - Puzzle
+
+- name: Super Cars
+  external:
+    wikipedia: Super Cars
+  meta:
+    genre:
+    - Racing
+
+- name: Super Foul Egg
+  external:
+    wikipedia: Super Foul Egg
+  meta:
+    genre:
+    - Puzzle
+    - Arcade
 
 - name: Super Hexagon
+  external:
+    wikipedia: Super Hexagon
   meta:
-    genre: [Rhythm]
+    genre:
+    - Rhythm
 
-- name: [SkyRoads, SkyRoads (video game)]
+- name: Super Mario
+  external:
+    wikipedia: Super Mario (series)
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
+
+- name: Super Methane Brothers
+  external:
+    wikipedia: Super Methane Bros.
+  meta:
+    genre:
+    - Platform
+    - Arcade
+
+- name: Super Monkey Ball
+  external:
+    wikipedia: Super Monkey Ball
+  meta:
+    genre:
+    - Arcade
+    - Platform
+
+- name: Survivor (1986)
+  external:
+    wikipedia: Survivor (video game)
+  meta:
+    genre:
+    - Puzzle
+
+- name: Swing
+  external:
+    wikipedia: Swing (video game)
+  meta:
+    genre:
+    - Puzzle
+    - Arcade
+
+- name: Syndicate
+  external:
+    wikipedia: Syndicate (video game)
+  meta:
+    genre:
+    - RTS
+
+- name: Syndicate Wars
+  external:
+    wikipedia: Syndicate Wars
+  meta:
+    genre:
+    - RTS
+
+- name: System Shock
+  external:
+    wikipedia: System Shock
+  meta:
+    genre:
+    - RPG
+    - FPS
+  names:
+  - 'System Shock: Enhanced Edition'
+  platform:
+  - DOS
+  - Windows
+

--- a/originals/t.yaml
+++ b/originals/t.yaml
@@ -1,241 +1,449 @@
-
-- name: [The Binding of Isaac, The Binding of Isaac (video game)]
+- name: Tempest
+  external:
+    wikipedia: Tempest (video game)
   meta:
-    genre: [Roguelike]
-
-- name: 'The Elder Scrolls: Arena'
-  meta:
-    genre: [RPG]
-
-- name: 'The Elder Scrolls II: Daggerfall'
-  meta:
-    genre: [RPG]
-
-- name: 'The Elder Scrolls III: Morrowind'
-  meta:
-    genre: [RPG]
-    theme: [Fantasy]
-
-- name: [The Goonies, The Goonies (video game)]
-  meta:
-    genre: [Platform]
-
-- name: [The Great Escape, The Great Escape (video game)]
-  meta:
-    genre: [Arcade]
-
-- name: The Great Giana Sisters
-  meta:
-    genre: [Platform]
-
-- name: The Sims Online
-  meta:
-    genre: [Simulation]
-    theme: [Management]
-
-- name: [The Lord of the Rings Volume 1, 'J.R.R. Tolkien''s The Lord of the Rings,
-      Vol. I (1990 video game)']
-  meta:
-    genre: [Action, RPG]
-
-- name: The Maze of Galious
-  meta:
-    genre: [Platform]
-
-- name: The Need for Speed
-  meta:
-    genre: [Racing]
-
-- name: The Adventures of Robbo
-  meta:
-    genre: [Puzzle]
-
-- name: [The Sentinel, The Sentinel (video game)]
-  meta:
-    genre: [Puzzle]
+    genre:
+    - Arcade
 
 - name: Terraria
+  external:
+    wikipedia: Terraria
   meta:
-    genre: [Action, Platform]
-    subgenre: [Survival, Sandbox]
-    theme: [Fantasy]
+    genre:
+    - Action
+    - Platform
+    subgenre:
+    - Survival
+    - Sandbox
+    theme:
+    - Fantasy
 
-- name: The Castles of Dr. Creep
+- name: Test Drive
+  external:
+    wikipedia: Test Drive (video game)
   meta:
-    genre: [Arcade]
-
-- name: The Clue!
-  meta:
-    genre: [Adventure]
-
-- name: [The Hobbit, The Hobbit (1982 video game)]
-  meta:
-    genre: [Adventure]
-
-- name: [The Incredible Machine, The_Incredible_Machine_(video_game)]
-  meta:
-    genre: [Puzzle, Simulation]
-
-- name: The Incredible Machine 2
-  meta:
-    genre: [Puzzle, Simulation]
-
-- name: The Incredible Machine 3
-  meta:
-    genre: [Puzzle, Simulation]
-
-- name: 'The Incredible Machine: Even More Contraptions'
-  meta:
-    genre: [Puzzle, Simulation]
-
-- name: The Last Ninja
-  meta:
-    genre: [Action, Adventure]
-
-- name: [The Settlers, The Settlers (video game)]
-  names: [Die Siedler, Serf City]
-  meta:
-    genre: [RTS]
-    subgenre: [City Building]
-    theme: [Medieval]
-
-- name: [The Settlers II, The Settlers II]
-  names: [Die Siedler II]
-  meta:
-    genre: [RTS]
-    subgenre: [City Building]
-    theme: [Medieval, Alternate Historical, Fantasy]
-
-- name: [The Settlers III, The Settlers III]
-  names: [Die Siedler III]
-  meta:
-    genre: [RTS]
-    subgenre: [City Building]
-    theme: [Egyptian, Alternate Historical, Fantasy]
-
-- name: [Tempest, Tempest (video game)]
-  meta:
-    genre: [Arcade]
-
-- name: [Test Drive, Test Drive (video game)]
-  meta:
-    genre: [Racing]
+    genre:
+    - Racing
 
 - name: Tetris
+  external:
+    wikipedia: Tetris
   meta:
-    genre: [Puzzle, Arcade]
+    genre:
+    - Puzzle
+    - Arcade
 
 - name: Tetris Attack
+  external:
+    wikipedia: Tetris Attack
   meta:
-    genre: [Puzzle, Arcade]
+    genre:
+    - Puzzle
+    - Arcade
 
-- name: Theme Hospital
+- name: The Adventures of Robbo
+  external:
+    wikipedia: The Adventures of Robbo
   meta:
-    genre: [Strategy, Simulation]
-    theme: [Management, Comedy]
+    genre:
+    - Puzzle
 
-- name: [Theme Park, Theme Park (video game)]
+- name: The Binding of Isaac
+  external:
+    wikipedia: The Binding of Isaac (video game)
   meta:
-    genre: [Strategy, Simulation]
-    theme: [Management, Comedy]
+    genre:
+    - Roguelike
 
-- name: [Thromolus, 'http://hol.abime.net/1386']
+- name: The Castles of Dr. Creep
+  external:
+    wikipedia: The Castles of Dr. Creep
   meta:
-    genre: [Puzzle]
+    genre:
+    - Arcade
 
-- name: [Thrust, Thrust (video game)]
+- name: The Clue!
+  external:
+    wikipedia: The Clue!
   meta:
-    genre: [Arcade]
+    genre:
+    - Adventure
 
-- name: Tiny Wings
+- name: 'The Elder Scrolls II: Daggerfall'
+  external:
+    wikipedia: 'The Elder Scrolls II: Daggerfall'
   meta:
-    genre: [Arcade]
+    genre:
+    - RPG
 
-- name: Titus the Fox
-  names:
-  - [Moktar, Titus the Fox]
+- name: 'The Elder Scrolls III: Morrowind'
+  external:
+    wikipedia: 'The Elder Scrolls III: Morrowind'
   meta:
-    genre: [Platform]
+    genre:
+    - RPG
+    theme:
+    - Fantasy
 
-- name: Total Annihilation
+- name: 'The Elder Scrolls: Arena'
+  external:
+    wikipedia: 'The Elder Scrolls: Arena'
   meta:
-    genre: [RTS]
+    genre:
+    - RPG
 
-- name: Tomb Raider
+- name: The Goonies
+  external:
+    wikipedia: The Goonies (video game)
   meta:
-    genre: [Platform, Adventure, Action]
+    genre:
+    - Platform
 
-- name: Toobz
-  platform: [Amiga]
+- name: The Great Escape
+  external:
+    wikipedia: The Great Escape (video game)
   meta:
-    genre: [Puzzle]
+    genre:
+    - Arcade
 
-- name: [Touhou, Touhou Project]
+- name: The Great Giana Sisters
+  external:
+    wikipedia: The Great Giana Sisters
   meta:
-    genre: [Shmup]
-    subgenre: [Bullet Hell]
-    theme: [Anime]
+    genre:
+    - Platform
 
-- name: TrackMania
+- name: The Hobbit
+  external:
+    wikipedia: The Hobbit (1982 video game)
   meta:
-    genre: [Racing]
+    genre:
+    - Adventure
 
-- name: [Transplant, Transplant (video game)]
+- name: The Incredible Machine
+  external:
+    wikipedia: The_Incredible_Machine_(video_game)
   meta:
-    genre: [Arcade]
+    genre:
+    - Puzzle
+    - Simulation
 
-- name: Transport Tycoon
+- name: The Incredible Machine 2
+  external:
+    wikipedia: The Incredible Machine 2
   meta:
-    genre: [Strategy, Simulation]
-    theme: [Management]
+    genre:
+    - Puzzle
+    - Simulation
 
-- name: Transport Tycoon Deluxe
+- name: The Incredible Machine 3
+  external:
+    wikipedia: The Incredible Machine 3
   meta:
-    genre: [Strategy, Simulation]
-    theme: [Management]
+    genre:
+    - Puzzle
+    - Simulation
 
-- name: Tranz Am
+- name: 'The Incredible Machine: Even More Contraptions'
+  external:
+    wikipedia: 'The Incredible Machine: Even More Contraptions'
   meta:
-    genre: [Arcade]
+    genre:
+    - Puzzle
+    - Simulation
 
-- name: [Tron, Tron (video game)]
+- name: The Last Ninja
+  external:
+    wikipedia: The Last Ninja
   meta:
-    genre: [Arcade]
+    genre:
+    - Action
+    - Adventure
 
-- name: [Turmoil, Turmoil (1984 video game)]
+- name: The Lord of the Rings Volume 1
+  external:
+    wikipedia: J.R.R. Tolkien's The Lord of the Rings, Vol. I (1990 video game)
   meta:
-    genre: [Arcade]
-
-- name: [Turnabout, Turnabout (video game)]
-  meta:
-    genre: [Puzzle]
-
-- name: [Turok, Turok (video game)]
-  meta:
-    genre: [FPS]
-
-- name: Turrican
-  meta:
-    genre: [Shmup]
-
-- name: [Tyrian, Tyrian (video game)]
-  meta:
-    genre: [Shmup]
+    genre:
+    - Action
+    - RPG
 
 - name: The Lost Vikings
+  external:
+    wikipedia: The Lost Vikings
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
 
-- name: [The Witcher, The Witcher (video game)]
+- name: The Maze of Galious
+  external:
+    wikipedia: The Maze of Galious
   meta:
-    genre: [RPG]
-    theme: [Fantasy]
+    genre:
+    - Platform
 
-- name: [Thief, Thief (series)]
+- name: The Need for Speed
+  external:
+    wikipedia: The Need for Speed
   meta:
-    genre: [Action, Adventure]
-    theme: [Crime, Fantasy]
+    genre:
+    - Racing
+
+- name: The Sentinel
+  external:
+    wikipedia: The Sentinel (video game)
+  meta:
+    genre:
+    - Puzzle
+
+- name: The Settlers
+  external:
+    wikipedia: The Settlers (video game)
+  meta:
+    genre:
+    - RTS
+    subgenre:
+    - City Building
+    theme:
+    - Medieval
+  names:
+  - Die Siedler
+  - Serf City
+
+- name: The Settlers II
+  external:
+    wikipedia: The Settlers II
+  meta:
+    genre:
+    - RTS
+    subgenre:
+    - City Building
+    theme:
+    - Medieval
+    - Alternate Historical
+    - Fantasy
+  names:
+  - Die Siedler II
+
+- name: The Settlers III
+  external:
+    wikipedia: The Settlers III
+  meta:
+    genre:
+    - RTS
+    subgenre:
+    - City Building
+    theme:
+    - Egyptian
+    - Alternate Historical
+    - Fantasy
+  names:
+  - Die Siedler III
+
+- name: The Sims Online
+  external:
+    wikipedia: The Sims Online
+  meta:
+    genre:
+    - Simulation
+    theme:
+    - Management
+
+- name: The Witcher
+  external:
+    wikipedia: The Witcher (video game)
+  meta:
+    genre:
+    - RPG
+    theme:
+    - Fantasy
+
+- name: Theme Hospital
+  external:
+    wikipedia: Theme Hospital
+  meta:
+    genre:
+    - Strategy
+    - Simulation
+    theme:
+    - Management
+    - Comedy
+
+- name: Theme Park
+  external:
+    wikipedia: Theme Park (video game)
+  meta:
+    genre:
+    - Strategy
+    - Simulation
+    theme:
+    - Management
+    - Comedy
+
+- name: Thief
+  external:
+    wikipedia: Thief (series)
+  meta:
+    genre:
+    - Action
+    - Adventure
+    theme:
+    - Crime
+    - Fantasy
+
+- name: Thromolus
+  external:
+    website: http://hol.abime.net/1386
+  meta:
+    genre:
+    - Puzzle
+
+- name: Thrust
+  external:
+    wikipedia: Thrust (video game)
+  meta:
+    genre:
+    - Arcade
+
+- name: Tiny Wings
+  external:
+    wikipedia: Tiny Wings
+  meta:
+    genre:
+    - Arcade
+
+- name: Titus the Fox
+  external:
+    wikipedia: Titus the Fox
+  meta:
+    genre:
+    - Platform
+  names:
+  - Moktar
+
+- name: Tomb Raider
+  external:
+    wikipedia: Tomb Raider
+  meta:
+    genre:
+    - Platform
+    - Adventure
+    - Action
+
+- name: Toobz
+  external:
+    wikipedia: Toobz
+  meta:
+    genre:
+    - Puzzle
+  platform:
+  - Amiga
+
+- name: Total Annihilation
+  external:
+    wikipedia: Total Annihilation
+  meta:
+    genre:
+    - RTS
+
+- name: Touhou
+  external:
+    wikipedia: Touhou Project
+  meta:
+    genre:
+    - Shmup
+    subgenre:
+    - Bullet Hell
+    theme:
+    - Anime
+
+- name: TrackMania
+  external:
+    wikipedia: TrackMania
+  meta:
+    genre:
+    - Racing
+
+- name: Transplant
+  external:
+    wikipedia: Transplant (video game)
+  meta:
+    genre:
+    - Arcade
+
+- name: Transport Tycoon
+  external:
+    wikipedia: Transport Tycoon
+  meta:
+    genre:
+    - Strategy
+    - Simulation
+    theme:
+    - Management
+
+- name: Transport Tycoon Deluxe
+  external:
+    wikipedia: Transport Tycoon Deluxe
+  meta:
+    genre:
+    - Strategy
+    - Simulation
+    theme:
+    - Management
+
+- name: Tranz Am
+  external:
+    wikipedia: Tranz Am
+  meta:
+    genre:
+    - Arcade
 
 - name: Tribal Hero
+  external:
+    wikipedia: Tribal Hero
   meta:
-    genre: [MMORPG]
+    genre:
+    - MMORPG
+
+- name: Tron
+  external:
+    wikipedia: Tron (video game)
+  meta:
+    genre:
+    - Arcade
+
+- name: Turmoil
+  external:
+    wikipedia: Turmoil (1984 video game)
+  meta:
+    genre:
+    - Arcade
+
+- name: Turnabout
+  external:
+    wikipedia: Turnabout (video game)
+  meta:
+    genre:
+    - Puzzle
+
+- name: Turok
+  external:
+    wikipedia: Turok (video game)
+  meta:
+    genre:
+    - FPS
+
+- name: Turrican
+  external:
+    wikipedia: Turrican
+  meta:
+    genre:
+    - Shmup
+
+- name: Tyrian
+  external:
+    wikipedia: Tyrian (video game)
+  meta:
+    genre:
+    - Shmup
+

--- a/originals/u.yaml
+++ b/originals/u.yaml
@@ -1,53 +1,100 @@
 - name: 'UFO: Enemy Unknown'
+  external:
+    wikipedia: 'UFO: Enemy Unknown'
   meta:
-    genre: [Strategy, RTS, Turn-Based Tactics]
-    theme: [Horror, Sci-Fi]
+    genre:
+    - Strategy
+    - RTS
+    - Turn-Based Tactics
+    theme:
+    - Horror
+    - Sci-Fi
 
 - name: Ugh!
+  external:
+    wikipedia: Ugh!
   meta:
-    genre: [Arcade]
-
-- name: 'Ultima: Worlds of Adventure 2: Martian Dreams'
-  meta:
-    genre: [RPG]
-
-- name: Ultima Online
-  meta:
-    genre: [MMORPG]
+    genre:
+    - Arcade
 
 - name: 'Ultima II: The Revenge of the Enchantress'
+  external:
+    wikipedia: 'Ultima II: The Revenge of the Enchantress'
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
 - name: Ultima IV
+  external:
+    wikipedia: Ultima IV
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
+
+- name: Ultima Online
+  external:
+    wikipedia: Ultima Online
+  meta:
+    genre:
+    - MMORPG
 
 - name: Ultima VI
+  external:
+    wikipedia: Ultima VI
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
 - name: Ultima VII
+  external:
+    wikipedia: Ultima VII
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
 - name: Ultima VIII
+  external:
+    wikipedia: Ultima VIII
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
+
+- name: 'Ultima: Worlds of Adventure 2: Martian Dreams'
+  external:
+    wikipedia: 'Ultima: Worlds of Adventure 2: Martian Dreams'
+  meta:
+    genre:
+    - RPG
 
 - name: Uncharted Waters
+  external:
+    wikipedia: Uncharted Waters
   meta:
-    genre: [Adventure, Strategy, RPG]
-    theme: [Alternate Historical]
+    genre:
+    - Adventure
+    - Strategy
+    - RPG
+    theme:
+    - Alternate Historical
 
-- name: [Uninvited, Uninvited (video game)]
+- name: Uninvited
+  external:
+    wikipedia: Uninvited (video game)
   meta:
-    genre: [Adventure]
+    genre:
+    - Adventure
 
 - name: Urban Assault
+  external:
+    wikipedia: Urban Assault
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
 
-- name: [Utopia, Utopia (video game)]
+- name: Utopia
+  external:
+    wikipedia: Utopia (video game)
   meta:
-    genre: [TBS]
+    genre:
+    - TBS
+

--- a/originals/v.yaml
+++ b/originals/v.yaml
@@ -1,16 +1,29 @@
-
-- name: [Vlak, 'http://www.mobygames.com/game/dos/vlak']
+- name: Viper
+  external:
+    website: http://www.mobygames.com/game/amiga/viper__
   meta:
-    genre: [Arcade]
-
-- name: [Viper, 'http://www.mobygames.com/game/amiga/viper__']
-  meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
 - name: Visual Pinball
+  external:
+    wikipedia: Visual Pinball
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
+
+- name: Vlak
+  external:
+    website: http://www.mobygames.com/game/dos/vlak
+  meta:
+    genre:
+    - Arcade
 
 - name: VVVVVV
+  external:
+    wikipedia: VVVVVV
   meta:
-    genre: [Puzzle, Platform]
+    genre:
+    - Puzzle
+    - Platform
+

--- a/originals/w.yaml
+++ b/originals/w.yaml
@@ -1,80 +1,142 @@
-
-- name: [Warlords II, Warlords (game series)#Warlords II]
+- name: Warcraft II
+  external:
+    wikipedia: Warcraft II
   meta:
-    genre: [TBS]
+    genre:
+    - RTS
 
 - name: 'Warcraft: Orcs & Humans'
+  external:
+    wikipedia: 'Warcraft: Orcs & Humans'
   meta:
-    genre: [RTS]
-
-- name: Warcraft II
-  meta:
-    genre: [RTS]
+    genre:
+    - RTS
 
 - name: Wario Land 3
+  external:
+    wikipedia: Wario Land 3
   meta:
-    genre: [Platform]
+    genre:
+    - Platform
+
+- name: Warlords II
+  external:
+    wikipedia: Warlords (game series)#Warlords II
+  meta:
+    genre:
+    - TBS
 
 - name: Warrior Kings
+  external:
+    wikipedia: Warrior Kings
   meta:
-    genre: [RTS]
+    genre:
+    - RTS
 
-- name : Warsong
+- name: Warsong
+  external:
+    wikipedia: Warsong
   meta:
-    genre: [TBS]
-    theme: [Fantasy]
+    genre:
+    - TBS
+    theme:
+    - Fantasy
 
 - name: Warzone 2100
+  external:
+    wikipedia: Warzone 2100
   meta:
-    genre: [RTS]
+    genre:
+    - RTS
 
 - name: Where in the World Is Carmen Sandiego? (1985)
+  external:
+    wikipedia: Where in the World Is Carmen Sandiego? (1985)
   meta:
-    genre: [Puzzle]
+    genre:
+    - Puzzle
 
-- name: [Willow, Willow (arcade game)]
+- name: Willow
+  external:
+    wikipedia: Willow (arcade game)
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
 - name: 'Wing Commander: Privateer'
+  external:
+    wikipedia: 'Wing Commander: Privateer'
   meta:
-    genre: [Action, Adventure, Simulation]
-    theme: [Sci-Fi]
+    genre:
+    - Action
+    - Adventure
+    - Simulation
+    theme:
+    - Sci-Fi
+
+- name: Wipeout
+  external:
+    wikipedia: Wipeout (video game)
+  meta:
+    genre:
+    - Racing
 
 - name: Wizard of Wor
+  external:
+    wikipedia: Wizard of Wor
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
 - name: Wizardry
+  external:
+    wikipedia: Wizardry
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
 - name: Wolfenstein 3D
+  external:
+    wikipedia: Wolfenstein 3D
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
 
 - name: 'Wolfenstein: Enemy Territory'
+  external:
+    wikipedia: 'Wolfenstein: Enemy Territory'
   meta:
-    genre: [FPS]
+    genre:
+    - FPS
 
 - name: World of Goo
+  external:
+    wikipedia: World of Goo
   meta:
-    genre: [Puzzle]
+    genre:
+    - Puzzle
 
 - name: World of Warcraft
+  external:
+    wikipedia: World of Warcraft
   meta:
-    genre: [MMORPG]
+    genre:
+    - MMORPG
     subgenre: []
-    theme: [Fantasy]
+    theme:
+    - Fantasy
 
 - name: 'Worlds of Ultima: The Savage Empire'
+  external:
+    wikipedia: 'Worlds of Ultima: The Savage Empire'
   meta:
-    genre: [RPG]
+    genre:
+    - RPG
 
-- name: [Worms Series, Worms (series)]
+- name: Worms Series
+  external:
+    wikipedia: Worms (series)
   meta:
-    genre: [TBS]
+    genre:
+    - TBS
 
-- name: [Wipeout, Wipeout (video game)]
-  meta:
-    genre: [Racing]

--- a/originals/x.yaml
+++ b/originals/x.yaml
@@ -1,35 +1,71 @@
-
-- name: 'X-COM: UFO Defense'
+- name: 'X-COM: Apocalypse'
+  external:
+    wikipedia: 'X-COM: Apocalypse'
   meta:
-    genre: [Strategy, RTS, Turn-Based Tactics]
-    theme: [Horror, Sci-Fi]
+    genre:
+    - Strategy
+    - RTS
+    - Turn-Based Tactics
+    theme:
+    - Horror
+    - Sci-Fi
 
 - name: 'X-COM: Terror from the Deep'
+  external:
+    wikipedia: 'X-COM: Terror from the Deep'
   meta:
-    genre: [Strategy, RTS, Turn-Based Tactics]
-    theme: [Horror, Sci-Fi]
+    genre:
+    - Strategy
+    - RTS
+    - Turn-Based Tactics
+    theme:
+    - Horror
+    - Sci-Fi
 
-- name: 'X-COM: Apocalypse'
+- name: 'X-COM: UFO Defense'
+  external:
+    wikipedia: 'X-COM: UFO Defense'
   meta:
-    genre: [Strategy, RTS, Turn-Based Tactics]
-    theme: [Horror, Sci-Fi]
+    genre:
+    - Strategy
+    - RTS
+    - Turn-Based Tactics
+    theme:
+    - Horror
+    - Sci-Fi
 
-- name: [X-It, 'http://www.mobygames.com/game/x-it']
+- name: X-It
+  external:
+    website: http://www.mobygames.com/game/x-it
   meta:
-    genre: [Puzzle]
+    genre:
+    - Puzzle
 
 - name: Xenon 2 Megablast
+  external:
+    wikipedia: Xenon 2 Megablast
   meta:
-    genre: [Shmup]
+    genre:
+    - Shmup
+
+- name: XOR
+  external:
+    wikipedia: XOR (video game)
+  meta:
+    genre:
+    - Puzzle
 
 - name: XPilot
+  external:
+    wikipedia: XPilot
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
-- name: [XQuest, 'http://www.swallowtail.org/xquest/']
+- name: XQuest
+  external:
+    website: http://www.swallowtail.org/xquest/
   meta:
-    genre: [Arcade]
+    genre:
+    - Arcade
 
-- name: [XOR, XOR (video game)]
-  meta:
-    genre: [Puzzle]

--- a/originals/z.yaml
+++ b/originals/z.yaml
@@ -1,25 +1,45 @@
-
-- name: [Z, Z (video game)]
+- name: Z
+  external:
+    wikipedia: Z (video game)
   meta:
-    genre: [RTS]
+    genre:
+    - RTS
 
 - name: Zarch
-  names: [Virus]
+  external:
+    wikipedia: Zarch
   meta:
-    genre: [Action, TPS]
+    genre:
+    - Action
+    - TPS
+  names:
+  - Virus
+
+- name: Zombie Apocalypse
+  external:
+    website: http://www.mobygames.com/game/zombie-apocalypse
+  meta:
+    genre:
+    - Shmup
 
 - name: Zoop
+  external:
+    wikipedia: Zoop
   meta:
-    genre: [Puzzle]
-
-- name: [Zombie Apocalypse, 'http://www.mobygames.com/game/zombie-apocalypse']
-  meta:
-    genre: [Shmup]
+    genre:
+    - Puzzle
 
 - name: Zork
+  external:
+    wikipedia: Zork
   meta:
-    genre: [Adventure]
+    genre:
+    - Adventure
 
-- name: [Zuma, Zuma (video game)]
+- name: Zuma
+  external:
+    wikipedia: Zuma (video game)
   meta:
-    genre: [Puzzle]
+    genre:
+    - Puzzle
+

--- a/schema/originals.yaml
+++ b/schema/originals.yaml
@@ -4,9 +4,19 @@ sequence:
     mapping:
       name:
         required: True
-        type: any
+        type: str
       names:
-        type: any
+        type: seq
+        sequence:
+          - type: str
+      external:
+        required: True
+        type: map
+        mapping:
+          website:
+            type: str
+          wikipedia:
+            type: str
       platform:
         type: seq
         sequence:

--- a/templates/games.html
+++ b/templates/games.html
@@ -1,14 +1,8 @@
 {% macro render_name(name, meta, idx, mode) %}
-  {%- if name is string -%}
-    {% set wiki = name %}
+  {%- if meta['external']['wikipedia'] -%}
+    {% set wikilink = "http://en.wikipedia.org/wiki/" + meta['external']['wikipedia'] %}
   {%- else -%}
-    {% set name, wiki = name %}
-  {%- endif -%}
-
-  {%- if wiki[:6] in ["http:/", "https:"] -%}
-    {% set wikilink = wiki %}
-  {%- else -%}
-    {% set wikilink = "http://en.wikipedia.org/wiki/" + wiki %}
+    {% set wikilink = meta['external']['website'] %}
   {%- endif -%}
 
   <dt {% if not idx %}id="{{ show_id(name, mode) }}"{% endif %} class="searchable">


### PR DESCRIPTION
Implements an idea similar to [this comment](https://github.com/opengaming/osgameclones/issues/501#issuecomment-348024836)

Not only does it make it cleaner, it also allows both wikipedia and official homepages (and possibly other pages as well) to be specified at the same time, possibly allowing links to be shown, for example, as wikipedia/homepage icons beside the name.

It also makes it a little clearer for those adding new original games that the wikipedia and/or website link must be checked.