### PR TITLE
Fix pushover links

### DIFF
--- a/games/p.yaml
+++ b/games/p.yaml
@@ -432,18 +432,18 @@
 
 - name: Pushover
   images:
-  - http://pushover.sourceforge.net/images/Screenshot2.jpg
-  - http://pushover.sourceforge.net/images/Screenshot3n.jpg
-  - http://pushover.sourceforge.net/images/Screenshot4.jpg
+  - https://pushover.github.io/website/images/Screenshot2.jpg
+  - https://pushover.github.io/website/images/Screenshot3n.jpg
+  - https://pushover.github.io/website/images/Screenshot4.jpg
   lang: C++
   development: sporadic
   originals:
   - Pushover
-  repo: http://pushover.sourceforge.net/repos/head/
+  repo: https://github.com/pushover/pushover.github.io
   status: playable
   type: remake
-  updated: 2013-05-29
-  url: http://pushover.sourceforge.net/
+  updated: 2013-05-19
+  url: https://pushover.github.io/
 
 - name: Py1945
   lang: Python


### PR DESCRIPTION
Fixes #602 

It seems https://github.com/pushover/pushover.github.io is the new repository for the game, not just the website.