### PR TITLE
[WIP] Polishing metadata

### DIFF
--- a/games/0.yaml
+++ b/games/0.yaml
@@ -9,10 +9,10 @@
   development: active
   originals:
   - Age of Empires
-  repo: http://trac.wildfiregames.com/timeline
+  repo: https://trac.wildfiregames.com/timeline
   status: playable
   type: clone
-  url: http://play0ad.com/
+  url: https://play0ad.com/
 
 - name: 1oom
   development: active
@@ -44,7 +44,7 @@
   repo: https://github.com/lo-th/3d.city
   type: clone
   updated: 2015-07-04
-  url: http://lo-th.github.io/3d.city/index.html
+  url: https://lo-th.github.io/3d.city/index.html
 
 - name: 4DTris
   lang: C
@@ -56,4 +56,4 @@
   repo: https://bazaar.launchpad.net/~4dtris-dev/4dtris/trunk/files
   type: clone
   updated: 2015-05-02
-  url: http://sourceforge.net/projects/dtris/
+  url: https://sourceforge.net/projects/dtris/

--- a/games/a.yaml
+++ b/games/a.yaml
@@ -116,10 +116,9 @@
   lang: C
   originals:
   - 'Akalabeth: World of Doom'
-  repo: http://www.robsons.org.uk/archive/www.autismuk.freeserve.co.uk/aklabeth-1.0.tar.gz
+  repo: https://sourceforge.net/projects/aklabeth/
   type: remake
   updated: 2015-04-13
-  url: http://www.robsons.org.uk/archive/www.autismuk.freeserve.co.uk/index.htm
 
 - name: Aleph One
   images:
@@ -156,7 +155,7 @@
   status: playable
   type: remake
   updated: 2014-01-12
-  url: http://retrospec.sgn.net/game/alien8
+  url: http://retrospec.sgn.net/users/ignacio/a8i.htm
 
 - name: alive
   images:
@@ -227,7 +226,7 @@
   repo: https://github.com/stephank/arashi-js
   type: remake
   updated: 2014-01-12
-  url: https://github.com/stephank/arashi-js
+  url: https://stephank.github.io/arashi-js/
 
 - name: Ard-Reil
   lang:
@@ -259,7 +258,7 @@
   video:
     youtube: Fxf6glufkWQ
 
-- name: Artillery Duel
+- name: Artillery Duel Reloaded
   images:
   - https://www.pygame.org/shots/1519.jpg
   lang: Python
@@ -268,10 +267,9 @@
   development: halted
   originals:
   - Artillery Duel
-  repo: http://artillery-duel-reloaded.googlecode.com/files/Artillery-0.61-src.zip
+  repo: https://code.google.com/archive/p/artillery-duel-reloaded/
   type: remake
   updated: 2015-04-11
-  url: https://code.google.com/p/artillery-duel-reloaded/
 
 - name: Arx Libertatis
   development: active
@@ -299,6 +297,7 @@
   repo: https://github.com/TimPietrusky/asdf
   type: remake
   updated: 2015-05-28
+  url: https://timpietrusky.github.io/asdf/
 
 - name: AstroMenace
   images:
@@ -348,6 +347,7 @@
   development: sporadic
   originals:
   - Scorched Earth
+  repo: https://sourceforge.net/projects/atanks/
   status: playable
   type: remake
   updated: 2013-06-06

--- a/games/a.yaml
+++ b/games/a.yaml
@@ -38,7 +38,7 @@
   status: playable
   type: remake
   updated: 2016-12-11
-  url: http://achtungkurve.com/
+  url: https://achtungkurve.com/
 
 - name: AdaDoom3
   lang: Ada
@@ -97,8 +97,8 @@
 
 - name: Ajax3d
   images:
-  - http://a.fsdn.com/con/app/proj/ajax3d/screenshots/113223.jpg
-  - http://a.fsdn.com/con/app/proj/ajax3d/screenshots/113221.jpg
+  - https://a.fsdn.com/con/app/proj/ajax3d/screenshots/113223.jpg
+  - https://a.fsdn.com/con/app/proj/ajax3d/screenshots/113221.jpg
   lang: JavaScript
   license:
   - GPL2
@@ -177,8 +177,8 @@
   - HTML5
   - Phaser
   images:
-  - http://ancientbeast.com/media/screenshots/v0.1%20Frozen%20Skull.jpg
-  - http://ancientbeast.com/media/screenshots/v0.1%20Dark%20Forest.jpg
+  - https://ancientbeast.com/media/screenshots/v0.1%20Frozen%20Skull.jpg
+  - https://ancientbeast.com/media/screenshots/v0.1%20Dark%20Forest.jpg
   lang: JavaScript
   development: active
   originals:
@@ -186,13 +186,13 @@
   repo: https://github.com/FreezingMoon/AncientBeast
   status: playable
   type: clone
-  url: http://AncientBeast.com
+  url: https://AncientBeast.com
 
 - name: Antares
   images:
-  - http://farm3.static.flickr.com/2606/4103057024_0b577de0a2.jpg
-  - http://farm3.static.flickr.com/2742/4102298687_8c2e12276b.jpg
-  - http://farm3.static.flickr.com/2597/4103065046_f52a39003f.jpg
+  - https://farm3.static.flickr.com/2606/4103057024_0b577de0a2.jpg
+  - https://farm3.static.flickr.com/2742/4102298687_8c2e12276b.jpg
+  - https://farm3.static.flickr.com/2597/4103065046_f52a39003f.jpg
   lang: C++
   license:
   - GPL3
@@ -203,7 +203,7 @@
   status: playable
   type: remake
   updated: 2014-08-20
-  url: http://arescentral.org/antares/
+  url: https://arescentral.org/antares/
   video:
     youtube: 4s44qu5zgXE
 
@@ -261,7 +261,7 @@
 
 - name: Artillery Duel
   images:
-  - http://pygame.org/shots/1519.jpg
+  - https://www.pygame.org/shots/1519.jpg
   lang: Python
   license:
   - GPL3

--- a/games/a.yaml
+++ b/games/a.yaml
@@ -105,7 +105,7 @@
   development: halted
   originals:
   - Zarch
-  repo: http://ajax3d.cvs.sourceforge.net/viewvc/ajax3d/
+  repo: https://sourceforge.net/projects/ajax3d/
   type: remake
   updated: 2015-10-09
   url: http://ajax3d.sourceforge.net/
@@ -240,7 +240,7 @@
   development: halted
   originals:
   - 'Anacreon: Reconstruction 4021'
-  repo: http://ardreil.cvs.sourceforge.net/viewvc/ardreil/
+  repo: https://sourceforge.net/projects/ardreil/
   type: remake
   updated: 2015-04-09
   url: http://ardreil.sourceforge.net/
@@ -314,10 +314,9 @@
   development: active
   originals:
   - AstroMenace
-  repo: svn://svn.code.sf.net/p/openastromenace/code/
+  repo: https://sourceforge.net/projects/openastromenace/
   type: remake
   updated: 2015-04-08
-  url: http://sourceforge.net/projects/openastromenace/
 
 - name: Atari8bit_StarRaiders
   info: reverse engineering project
@@ -362,7 +361,7 @@
   content: commercial
   originals:
   - Atomix
-  repo: https://sourceforge.net/projects/atomiks/files/
+  repo: https://sourceforge.net/projects/atomiks/
   status: playable
   type: remake
   url: http://atomiks.sourceforge.net/

--- a/games/b.yaml
+++ b/games/b.yaml
@@ -213,7 +213,7 @@
   development: halted
   originals:
   - Bomberman
-  repo: svn://svn.code.sf.net/p/bomb-mania/code-0/trunk
+  repo: https://sourceforge.net/projects/bomb-mania/
   type: remake
   updated: 2015-04-14
   url: https://sourceforge.net/p/bomb-mania/wiki/Home/
@@ -228,7 +228,7 @@
   development: halted
   originals:
   - Bomberman
-  repo: svn://svn.code.sf.net/p/bombic/code/
+  repo: https://sourceforge.net/projects/bombic/
   type: remake
   updated: 2015-04-14
   url: http://bombic.sourceforge.net/
@@ -245,7 +245,7 @@
   development: halted
   originals:
   - Bomberman
-  repo: svn://svn.code.sf.net/p/bombic2/code/
+  repo: https://sourceforge.net/projects/bombic2/
   type: remake
   updated: 2015-04-14
   url: http://bombic2.sourceforge.net/
@@ -361,7 +361,7 @@
   development: halted
   originals:
   - Battle Chess
-  repo: svn://svn.code.sf.net/p/brutalchess/code/trunk
+  repo: https://sourceforge.net/projects/brutalchess/
   type: clone
   updated: 2015-04-08
   url: http://sourceforge.net/projects/brutalchess/

--- a/games/b.yaml
+++ b/games/b.yaml
@@ -9,7 +9,7 @@
   repo: https://compiler.speccy.org/files/sources/Babaliba_Source.zip
   type: remake
   updated: 2015-04-13
-  url: https://compiler.speccy.org/remakes-babaliba.html
+  url: https://compiler.speccy.org/en/remakes-babaliba.html
 
 - name: back-to-nature-c64-remake
   info: multi-platform
@@ -31,6 +31,7 @@
   repo: https://github.com/budnix/ball-and-wall
   type: clone
   updated: 2015-05-03
+  url: https://budnix.github.io/ball-and-wall/
 
 - name: Ballerburg SDL
   images:
@@ -185,7 +186,7 @@
   development: active
   originals:
   - Blood
-  repo: http://m210.ucoz.ru/
+  repo: https://m210.duke4.net/
   type: remake
   updated: 2013-05-29
   url: https://www.moddb.com/games/bloodcm
@@ -293,9 +294,6 @@
   updated: 2015-05-15
 
 - name: Breakout VR
-  images:
-  - https://raw.githubusercontent.com/marksteelz3/Breakout-VR/master/Breakout%20VR%201.0%20Capture.PNG
-  - https://raw.githubusercontent.com/marksteelz3/Breakout-VR/master/Breakout%20VR%201.0%20Capture%202.PNG
   lang:
   - C#
   - ASP
@@ -305,7 +303,7 @@
   development: sporadic
   originals:
   - Breakout
-  repo: https://github.com/marksteelz3/Breakout-VR
+  repo: https://github.com/marksteelz3/Atari-VR---Breakout
   type: clone
   updated: 2017-12-12
 
@@ -342,7 +340,7 @@
   development: halted
   originals:
   - Breakout
-  repo: http://briquolo.free.fr/download/briquolo-0.5.7.tar.bz2
+  repo: http://briquolo.free.fr/en/download.html
   type: clone
   updated: 2015-04-25
   url: http://briquolo.free.fr/en/index.html
@@ -354,7 +352,6 @@
   - https://a.fsdn.com/con/app/proj/brutalchess/screenshots/59140.jpg
   - https://a.fsdn.com/con/app/proj/brutalchess/screenshots/107538.jpg
   - https://a.fsdn.com/con/app/proj/brutalchess/screenshots/89261.jpg
-  - https://a.fsdn.com/con/app/proj/brutalchess/screenshots/89261.jpg
   lang: C++
   license:
   - GPL2
@@ -364,9 +361,8 @@
   repo: https://sourceforge.net/projects/brutalchess/
   type: clone
   updated: 2015-04-08
-  url: http://sourceforge.net/projects/brutalchess/
 
-- name: bstone
+- name: BStone
   lang: C++
   development: active
   originals:
@@ -375,6 +371,7 @@
   status: playable
   type: remake
   updated: 2013-12-02
+  url: https://bibendovsky.github.io/bstone/
 
 - name: Bt Builder
   lang: C++

--- a/games/b.yaml
+++ b/games/b.yaml
@@ -34,18 +34,18 @@
 
 - name: Ballerburg SDL
   images:
-  - http://baller.tuxfamily.org/screenshot1.png
-  - http://baller.tuxfamily.org/screenshot2.png
+  - https://baller.tuxfamily.org/screenshot1.png
+  - https://baller.tuxfamily.org/screenshot2.png
   lang: C
   license:
   - GPL3
   development: active
   originals:
   - Ballerburg
-  repo: http://git.tuxfamily.org/baller/baller.git/
+  repo: https://git.tuxfamily.org/baller/baller.git/
   type: remake
   updated: 2015-04-17
-  url: http://baller.tuxfamily.org/
+  url: https://baller.tuxfamily.org/
 
 - name: Balloon Fight
   framework: DIV Games Studio
@@ -74,22 +74,22 @@
 
 - name: Batrachians
   images:
-  - http://perso.b2b2c.ca/~sarrazip/dev/images/batrachians-1.png
+  - https://perso.b2b2c.ca/~sarrazip/dev/images/batrachians-1.png
   lang: C++
   license:
   - GPL2
   development: halted
   originals:
   - Frogs and Flies
-  repo: http://perso.b2b2c.ca/~sarrazip/dev/batrachians-0.1.6.tar.gz
+  repo: https://perso.b2b2c.ca/~sarrazip/dev/batrachians-0.1.6.tar.gz
   type: remake
   updated: 2015-04-16
-  url: http://perso.b2b2c.ca/~sarrazip/dev/batrachians.html
+  url: https://perso.b2b2c.ca/~sarrazip/dev/batrachians.html
 
 - name: Battle City
   images:
-  - http://battlecity.org/wp-content/uploads/your-city-has-been-destroyed-by-the-power-of-an-orb.png
-  - http://farm6.staticflickr.com/5246/5313969457_15de8df27f_z.jpg
+  - https://battlecity.org/wp-content/uploads/your-city-has-been-destroyed-by-the-power-of-an-orb.png
+  - https://farm6.staticflickr.com/5246/5313969457_15de8df27f_z.jpg
   lang: C++
   license:
   - GPL3
@@ -100,7 +100,7 @@
   status: playable
   type: remake
   updated: 2017-02-09
-  url: http://battlecity.org/
+  url: https://battlecity.org/
 
 - name: BattleCity2014
   framework:
@@ -169,7 +169,7 @@
 - name: Block Attack - Rise of the Blocks
   framework: SDL2
   images:
-  - http://www.blockattack.net/images/blockattack-2.0.0-1.png
+  - https://blockattack.net/images/blockattack-2.0.0-1.png
   lang: C++
   license:
   - GPL
@@ -179,7 +179,7 @@
   repo: https://github.com/blockattack/blockattack-game
   type: clone
   updated: 2016-05-01
-  url: http://www.blockattack.net
+  url: https://blockattack.net/
 
 - name: Blood Crossmatching (EDuke32 vanilla)
   development: active
@@ -188,7 +188,7 @@
   repo: http://m210.ucoz.ru/
   type: remake
   updated: 2013-05-29
-  url: http://www.moddb.com/games/bloodcm
+  url: https://www.moddb.com/games/bloodcm
 
 - name: BloonsTowerDefense6
   lang: Java
@@ -216,7 +216,7 @@
   repo: svn://svn.code.sf.net/p/bomb-mania/code-0/trunk
   type: remake
   updated: 2015-04-14
-  url: http://sourceforge.net/p/bomb-mania/wiki/Home/
+  url: https://sourceforge.net/p/bomb-mania/wiki/Home/
 
 - name: Bombic
   images:
@@ -390,7 +390,7 @@
 
 - name: BurgerSpace
   images:
-  - http://perso.b2b2c.ca/~sarrazip/dev/images/burgerspace-1.png
+  - https://perso.b2b2c.ca/~sarrazip/dev/images/burgerspace-1.png
   lang: C++
   license:
   - GPL2
@@ -404,9 +404,9 @@
 
 - name: BZFlag
   images:
-  - http://bzflag.org/images/screenshots/dantes_inferno_01.jpg
-  - http://bzflag.org/images/screenshots/collaborator_2010_01.jpg
-  - http://bzflag.org/images/screenshots/delirious_city_03.jpg
+  - https://www.bzflag.org/images/screenshots/dantes_inferno_01.jpg
+  - https://www.bzflag.org/images/screenshots/collaborator_2010_01.jpg
+  - https://www.bzflag.org/images/screenshots/delirious_city_03.jpg
   lang: C++
   development: active
   originals:
@@ -414,4 +414,4 @@
   repo: https://github.com/BZFlag-Dev/bzflag
   status: playable
   type: clone
-  url: http://bzflag.org/
+  url: https://bzflag.org/

--- a/games/c.yaml
+++ b/games/c.yaml
@@ -79,7 +79,7 @@
   status: playable
   type: remake
   updated: 2013-05-27
-  url: https://bitbucket.org/dalerank/caesaria
+  url: https://bitbucket.org/dalerank/caesaria/wiki/Home
 
 - name: Cannon Fodder
   framework: HTML5
@@ -102,7 +102,7 @@
   status: playable
   type: remake
   updated: 2014-02-06
-  url: https://github.com/djyt/cannonball/wiki
+  url: https://reassembler.blogspot.com/
 
 - name: Castle of the Winds in Elm
   lang:
@@ -166,7 +166,6 @@
   status: playable
   type: remake
   updated: 2014-07-23
-  url: https://github.com/Blzut3/CatacombSDL
 
 - name: CaveExpress
   framework: SDL
@@ -216,6 +215,7 @@
   repo: https://github.com/institution/cc94
   type: remake
   updated: 2015-05-29
+  url: https://institution.github.io/cc94/
 
 - name: chainreaction
   lang:
@@ -273,7 +273,7 @@
   - Doom II
   - Heretic
   - Hexen
-  repo: http://chocolate-doom.svn.sourceforge.net/viewvc/chocolate-doom/
+  repo: https://github.com/chocolate-doom/chocolate-doom
   type: remake
   url: https://www.chocolate-doom.org/
 
@@ -346,6 +346,7 @@
   repo: https://github.com/ellisonleao/clumsy-bird
   type: remake
   updated: 2015-05-02
+  url: https://ellisonleao.github.io/clumsy-bird/
 
 - name: coab
   lang: C#
@@ -359,13 +360,12 @@
   type: remake
   updated: 2013-05-28
 
-- name: Colditz Escape!
+- name: Colditz Escape
   images:
-  - https://sites.google.com/site/colditzescape/home/screenshot0.png
-  - https://sites.google.com/site/colditzescape/home/screenshot1.png
-  - https://sites.google.com/site/colditzescape/home/screenshot2.png
-  - https://sites.google.com/site/colditzescape/home/screenshot3.png
-  - https://sites.google.com/site/colditzescape/home/screenshot4.png
+  - https://aperture-software.github.io/colditz-escape/pics/screenshot1.png
+  - https://aperture-software.github.io/colditz-escape/pics/screenshot2.png
+  - https://aperture-software.github.io/colditz-escape/pics/screenshot3.png
+  - https://aperture-software.github.io/colditz-escape/pics/screenshot4.png
   lang: C
   license:
   - GPL3
@@ -375,7 +375,7 @@
   repo: https://github.com/aperture-software/colditz-escape
   type: remake
   updated: 2015-04-10
-  url: https://sites.google.com/site/colditzescape/
+  url: https://aperture-software.github.io/colditz-escape/
 
 - name: Commander Genius
   images:
@@ -389,7 +389,7 @@
   development: active
   originals:
   - Commander Keen Series
-  repo: https://github.com/gerstrong/Commander-Genius
+  repo: https://gitlab.com/Dringgstein/Commander-Genius
   type: remake
   url: http://clonekeenplus.sourceforge.net/
 
@@ -421,6 +421,7 @@
   repo: https://github.com/EmileSonneveld/Contra_remake
   type: remake
   updated: 2015-05-28
+  url: https://emilesonneveld.be/contra/
   video:
     vimeo: 79514269
 
@@ -469,7 +470,7 @@
   content: commercial
   originals:
   - Theme Hospital
-  repo: https://github.com/CorsixTH
+  repo: https://github.com/CorsixTH/CorsixTH
   status: playable
   type: remake
   url: http://corsixth.com/
@@ -525,6 +526,7 @@
   repo: https://github.com/varunpant/CrappyBird
   type: remake
   updated: 2015-05-02
+  url: https://varunpant.com/static/resources/CrappyBird/index.html
 
 - name: Crazy Cars
   images:
@@ -548,7 +550,6 @@
   development: sporadic
   originals:
   - Battle Isle series
-  repo: http://svn.seul.org/viewcvs/viewvc.cgi/games/crimson/?root=SEUL
   status: playable
   type: clone
   updated: 2013-05-29
@@ -583,6 +584,7 @@
   repo: https://github.com/haleymt/CrystalQuest
   type: remake
   updated: 2015-05-29
+  url: https://haleymt.github.io/CrystalQuest/
 
 - name: Cubosphere
   lang: C++

--- a/games/c.yaml
+++ b/games/c.yaml
@@ -126,7 +126,7 @@
   development: halted
   originals:
   - Rampart
-  repo: https://sourceforge.net/projects/castle-combat/files/castle-combat/
+  repo: https://sourceforge.net/projects/castle-combat/
   status: playable
   type: remake
   url: https://www.linux-games.com/castle-combat/
@@ -565,7 +565,7 @@
   development: halted
   originals:
   - Sid Meier's Pirates!
-  repo: svn://svn.code.sf.net/p/crownandcutlass/code/trunk
+  repo: https://sourceforge.net/projects/crownandcutlass/
   type: remake
   updated: 2015-04-15
   url: http://www.crownandcutlass.com/
@@ -591,10 +591,9 @@
   development: halted
   originals:
   - Kula World
-  repo: http://cubosphere.bzr.sourceforge.net/bzr/cubosphere/changes
+  repo: http://sourceforge.net/projects/cubosphere/
   type: remake
   updated: 2015-04-14
-  url: http://sourceforge.net/projects/cubosphere/
 
 - name: Cytadela
   images:
@@ -609,7 +608,7 @@
   development: sporadic
   originals:
   - Cytadela
-  repo: http://heanet.dl.sourceforge.net/project/cytadela/cytadela/1.1.0/cytadela-1.1.0.tar.bz2
+  repo: https://sourceforge.net/projects/cytadela/
   type: remake
   updated: 2015-04-16
-  url: http://cytadela.sourceforge.net/about.php
+  url: http://cytadela.sourceforge.net/

--- a/games/c.yaml
+++ b/games/c.yaml
@@ -14,10 +14,10 @@
   feed: http://cxong.github.io/cdogs-sdl/feed.xml
   framework: SDL2
   images:
-  - http://raw.github.com/cxong/cdogs-sdl/master/wiki/images/thumbs/1.png
-  - http://raw.github.com/cxong/cdogs-sdl/master/wiki/images/thumbs/2.png
-  - http://raw.github.com/cxong/cdogs-sdl/master/wiki/images/thumbs/3.png
-  - http://raw.github.com/cxong/cdogs-sdl/master/wiki/images/thumbs/4.png
+  - https://raw.github.com/cxong/cdogs-sdl/master/wiki/images/thumbs/1.png
+  - https://raw.github.com/cxong/cdogs-sdl/master/wiki/images/thumbs/2.png
+  - https://raw.github.com/cxong/cdogs-sdl/master/wiki/images/thumbs/3.png
+  - https://raw.github.com/cxong/cdogs-sdl/master/wiki/images/thumbs/4.png
   lang: C
   license:
   - GPL2
@@ -29,7 +29,7 @@
   status: playable
   type: remake
   updated: 2014-03-08
-  url: http://cxong.github.io/cdogs-sdl/
+  url: https://cxong.github.io/cdogs-sdl/
   video:
     youtube: hgX3jz_HajE
 
@@ -129,7 +129,7 @@
   repo: https://sourceforge.net/projects/castle-combat/files/castle-combat/
   status: playable
   type: remake
-  url: http://www.linux-games.com/castle-combat/
+  url: https://www.linux-games.com/castle-combat/
 
 - name: 'Cataclysm: Dark Days Ahead'
   framework: ncurses
@@ -148,7 +148,7 @@
   status: playable
   type: remake
   updated: 2016-10-09
-  url: http://en.cataclysmdda.com/
+  url: https://cataclysmdda.org/
   video:
     youtube: iHfpBze8ecA
 
@@ -257,14 +257,13 @@
   status: unplayable
   type: remake
   updated: 2017-05-27
-  url: https://github.com/ChariotEngine/Chariot
 
 - name: Chocolate Doom
   images:
-  - http://www.chocolate-doom.org/wiki/images/9/9f/Chocolate-aliens-doom.png
-  - http://www.chocolate-doom.org/wiki/images/6/6b/Chocolate-aod-doom.png
-  - http://www.chocolate-doom.org/wiki/images/e/e3/Chocolate-batman-doom.png
-  - http://www.chocolate-doom.org/wiki/images/d/d5/Obituary.png
+  - https://www.chocolate-doom.org/wiki/images/9/9f/Chocolate-aliens-doom.png
+  - https://www.chocolate-doom.org/wiki/images/6/6b/Chocolate-aod-doom.png
+  - https://www.chocolate-doom.org/wiki/images/e/e3/Chocolate-batman-doom.png
+  - https://www.chocolate-doom.org/wiki/images/d/d5/Obituary.png
   lang: C
   license:
   - GPL2
@@ -276,7 +275,7 @@
   - Hexen
   repo: http://chocolate-doom.svn.sourceforge.net/viewvc/chocolate-doom/
   type: remake
-  url: http://www.chocolate-doom.org/
+  url: https://www.chocolate-doom.org/
 
 - name: Circus Linux!
   images:
@@ -322,7 +321,7 @@
   repo: https://ctp2.darkdust.net/svn/
   type: remake
   updated: 2015-04-10
-  url: http://ctp2.darkdust.net/
+  url: https://ctp2.darkdust.net/
 
 - name: CivOne
   development: active
@@ -335,7 +334,7 @@
   repo: https://github.com/SWY1985/CivOne
   type: remake
   updated: 2016-05-09
-  url: http://www.civone.com/
+  url: https://www.civone.org/
 
 - name: Clumsy Bird
   framework: MelonJS
@@ -453,14 +452,14 @@
   repo: https://github.com/core-code/CoreBreach
   type: clone
   updated: 2015-04-05
-  url: http://corebreach.corecode.at/CoreBreach/CoreBreach.html
+  url: https://www.corecode.io/corebreach/CoreBreach/CoreBreach.html
 
 - name: CorsixTH
   development: active
   framework:
   - SDL2
   images:
-  - http://th.corsix.org/CorsixTH08.jpg
+  - https://th.corsix.org/CorsixTH08.jpg
   info: time-based releases
   lang:
   - C++
@@ -490,7 +489,7 @@
 - name: Cosmosmash
   framework: SDL
   images:
-  - http://perso.b2b2c.ca/~sarrazip/dev/images/cosmosmash-1.png
+  - https://perso.b2b2c.ca/~sarrazip/dev/images/cosmosmash-1.png
   lang: C++
   license:
   - GPL2
@@ -504,7 +503,7 @@
 
 - name: Crack Attack!
   images:
-  - http://www.nongnu.org/crack-attack/gui-1.1.14-normal.png
+  - https://www.nongnu.org/crack-attack/gui-1.1.14-normal.png
   info: networking support
   lang: C++
   development: halted
@@ -514,7 +513,7 @@
   status: playable
   type: remake
   updated: 2014-04-16
-  url: http://www.nongnu.org/crack-attack/
+  url: https://www.nongnu.org/crack-attack/
 
 - name: CrappyBird
   lang: JavaScript

--- a/games/d.yaml
+++ b/games/d.yaml
@@ -4,7 +4,7 @@
   originals:
   - Descent
   - Descent II
-  repo: http://d2x-xl.svn.sourceforge.net/viewvc/d2x-xl/
+  repo: https://sourceforge.net/projects/d2x-xl/
   type: remake
   url: http://www.descent2.de/
   video:
@@ -21,7 +21,7 @@
   status: playable
   type: remake
   updated: 2016-10-11
-  url: http://www.dfworkshop.net/
+  url: https://www.dfworkshop.net/
 
 - name: Daggerfall.NET
   lang: C#
@@ -42,21 +42,10 @@
   development: sporadic
   originals:
   - Silent Hunter 4
-  repo: http://dangerdeep.svn.sourceforge.net/viewvc/dangerdeep/
+  repo: https://sourceforge.net/projects/dangerdeep/
   type: remake
   updated: 2012-04-05
   url: http://dangerdeep.sourceforge.net/
-
-- name: Danger Zone
-  lang: Java
-  development: active
-  originals:
-  - Tribal Hero
-  repo: https://github.com/alasershark/dangerzone
-  status: unplayable
-  type: clone
-  updated: 2013-05-28
-  url: http://dzgame.org
 
 - name: Dark Oberon
   images:
@@ -65,7 +54,7 @@
   - http://dark-oberon.sourceforge.net/screenshots/2005-08-16_7_1024x768.jpg
   originals:
   - Warcraft II
-  repo: http://dark-oberon.cvs.sourceforge.net/viewvc/dark-oberon/
+  repo: https://sourceforge.net/projects/dark-oberon/
   type: clone
   updated: 2015-04-06
   url: http://dark-oberon.sourceforge.net/
@@ -75,9 +64,8 @@
   development: halted
   originals:
   - Dark Reign 2
-  repo: http://darkreign2.googlecode.com/svn/
+  repo: https://code.google.com/archive/p/darkreign2/
   type: remake
-  url: https://code.google.com/p/darkreign2/
 
 - name: DarkFO
   development: active
@@ -90,9 +78,9 @@
   originals:
   - Fallout 2
   status: unplayable
+  repo: https://github.com/darkf/darkfo
   type: remake
   updated: 2015-12-30
-  url: https://github.com/darkf/darkfo
 
 - name: DarkPlaces
   images:
@@ -126,8 +114,8 @@
   framework:
   - SDL
   images:
-  - http://scorpioncity.com/dave_gnukem/gallery/Dave%20Gnukem%20%280.71%202%20Jul%202017%29.png
-  - http://djoffe.com/gnukem/files/Dave_Gnukem_0.81.png
+  - https://scorpioncity.com/dave_gnukem/gallery/Dave%20Gnukem%20(0.71%202%20Jul%202017).png
+  - https://djoffe.com/gnukem/files/Dave_Gnukem_0.81.png
   lang:
   - C++
   license:
@@ -139,7 +127,7 @@
   status: playable
   type: clone
   updated: 2018-01-23
-  url: http://djoffe.com/gnukem/
+  url: https://djoffe.com/gnukem/
   video:
     youtube: Hi7WYnOA_fo
 
@@ -149,10 +137,10 @@
   lang: C
   originals:
   - 3D Deathchase
-  repo: http://www.robsons.org.uk/archive/www.autismuk.freeserve.co.uk/deathchase3d-0.9.tar.gz
+  repo: https://web.archive.org/web/20070711231311/http://www.robsons.org.uk/archive/www.autismuk.freeserve.co.uk/deathchase3d-0.9.tar.gz
   type: remake
   updated: 2015-04-13
-  url: http://www.robsons.org.uk/archive/www.autismuk.freeserve.co.uk/index.htm
+  url: https://web.archive.org/web/20070711231311/http://www.robsons.org.uk/archive/www.autismuk.freeserve.co.uk/index.htm
 
 - name: Defendguin
   images:
@@ -182,9 +170,10 @@
   development: halted
   originals:
   - Deflektor
+  repo: http://retrospec.sgn.net/users/ignacio/downloads/deflektor_x4_f.zip
   type: remake
   updated: 2014-01-12
-  url: http://retrospec.sgn.net/game/deflektorx4
+  url: http://retrospec.sgn.net/users/ignacio/dfli.htm
 
 - name: Der Clou!
   images:
@@ -221,10 +210,10 @@
   development: halted
   originals:
   - Deuteros
-  repo: svn://svn.code.sf.net/p/deuterosx/code/
+  repo: http://sourceforge.net/projects/deuterosx/
   type: remake
   updated: 2015-04-06
-  url: http://sourceforge.net/projects/deuterosx/
+  url: http://deuterosx.org/
 
 - name: Devilution
   images:
@@ -243,7 +232,7 @@
 
 - name: DGEngine
   images:
-  - https://cloud.githubusercontent.com/assets/20025614/16467025/4bd77ef0-3e3d-11e6-872a-38ca8eb2c9f8.gif
+  - https://user-images.githubusercontent.com/20025614/30250613-4033a546-9649-11e7-86d7-97a718d0f119.gif
   lang:
   - C++
   license:
@@ -266,6 +255,7 @@
   repo: https://github.com/dhewm/dhewm3
   type: remake
   updated: 2015-07-29
+  url: https://dhewm3.org/
 
 - name: Digbuild
   images:
@@ -289,6 +279,7 @@
   repo: https://github.com/lutzroeder/digger
   type: remake
   updated: 2015-05-02
+  url: https://lutzroeder.github.io/digger/
 
 - name: Digger Remastered
   images:
@@ -299,10 +290,10 @@
   development: halted
   originals:
   - Digger
-  repo: http://digger.org/download.html
+  repo: https://digger.org/download.html
   status: playable
   type: remake
-  url: http://digger.org/
+  url: https://digger.org/
 
 - name: Digimon World Project Ark
   framework: Unity
@@ -408,7 +399,7 @@
   - Doom II
   - Heretic
   - Hexen
-  repo: http://sourceforge.net/p/doomlegacy/legacy2/ci/master/tree/
+  repo: https://sourceforge.net/projects/doomlegacy/
   status: playable
   type: remake
   updated: 2014-08-20
@@ -439,7 +430,7 @@
   - Doom II
   - Heretic
   - Hexen
-  repo: http://deng.git.sourceforge.net/git/gitweb.cgi?p=deng/deng;a=summary
+  repo: https://github.com/skyjake/Doomsday-Engine
   type: remake
   url: http://dengine.net/
 
@@ -451,16 +442,16 @@
   development: sporadic
   originals:
   - Drugwars
-  repo: http://sourceforge.net/p/dopewars/code/HEAD/tree/
+  repo: https://sourceforge.net/projects/dopewars/
   type: remake
   updated: 2013-05-27
-  url: http://dopewars.sourceforge.net/
+  url: https://dopewars.sourceforge.io/
 
 - name: DrCreep
   images:
-  - http://a.fsdn.com/con/app/proj/creep/screenshots/250988.jpg
-  - http://a.fsdn.com/con/app/proj/creep/screenshots/250982.jpg
-  - http://a.fsdn.com/con/app/proj/creep/screenshots/250990.jpg
+  - https://a.fsdn.com/con/app/proj/creep/screenshots/250988.jpg
+  - https://a.fsdn.com/con/app/proj/creep/screenshots/250982.jpg
+  - https://a.fsdn.com/con/app/proj/creep/screenshots/250990.jpg
   lang: C++
   development: complete
   originals:
@@ -472,7 +463,7 @@
 
 - name: Duck Hunter
   images:
-  - http://pygame.org/shots/1615.png
+  - https://pygame.org/shots/1615.png
   lang: Python
   development: halted
   originals:
@@ -480,7 +471,7 @@
   repo: https://app.box.com/shared/zkh7rt575i
   type: remake
   updated: 2015-04-11
-  url: http://pygame.org/project-Duck+Hunter-1615-.html
+  url: https://pygame.org/project-Duck+Hunter-1615-.html
 
 - name: Duck Marines
   images:
@@ -505,7 +496,7 @@
 
 - name: Duck-Rehunt
   images:
-  - http://pygame.org/shots/1862.png
+  - https://pygame.org/shots/1862.png
   lang: Python
   license:
   - GPL
@@ -515,11 +506,11 @@
   repo: https://github.com/Serioussam24/Duck-Rehunt
   type: remake
   updated: 2015-04-11
-  url: http://pygame.org/project-Duck+Rehunt-1862-.html
+  url: https://pygame.org/project-Duck+Rehunt-1862-.html
 
 - name: duckhunt
   images:
-  - http://pygame.org/shots/2045.png
+  - https://pygame.org/shots/2045.png
   lang: Python
   development: sporadic
   originals:
@@ -527,7 +518,7 @@
   repo: https://github.com/aosyborg/duckhunt
   type: remake
   updated: 2015-04-05
-  url: http://pygame.org/project-Duck+Hunt+Remake-2045-.html
+  url: https://pygame.org/project-Duck+Hunt+Remake-2045-.html
 
 - name: duckhunt
   lang: JavaScript
@@ -537,7 +528,7 @@
   repo: https://github.com/grosbouddha/duckhunt
   type: remake
   updated: 2015-05-28
-  url: http://grosbouddha.github.io/duckhunt/
+  url: https://grosbouddha.github.io/duckhunt/
 
 - name: Dune 2 - The Maker
   images:
@@ -557,16 +548,17 @@
 
 - name: Dune Dynasty
   images:
-  - https://sourceforge.net/projects/dunedynasty/screenshots/screenshot_hark2.png
-  - https://a.fsdn.com/con/app/proj/dunedynasty/screenshots/screenshot_hark.png
-  - https://a.fsdn.com/con/app/proj/dunedynasty/screenshots/screenshot_atr.png
+  - https://a.fsdn.com/con/app/proj/dunedynasty/screenshots/screenshot_ord.png/max/max/1
+  - https://a.fsdn.com/con/app/proj/dunedynasty/screenshots/screenshot_hark2.png/max/max/1
+  - https://a.fsdn.com/con/app/proj/dunedynasty/screenshots/screenshot_hark.png/max/max/1
+  - https://a.fsdn.com/con/app/proj/dunedynasty/screenshots/screenshot_atr.png/max/max/1
   lang: C
   license:
   - GPL2
   development: active
   originals:
   - Dune 2
-  repo: http://sourceforge.net/p/dunedynasty/dunedynasty/ci/master/tree/
+  repo: https://sourceforge.net/projects/dunedynasty/
   type: remake
   url: http://dunedynasty.sourceforge.net/
 
@@ -580,7 +572,7 @@
   development: active
   originals:
   - Dune 2
-  repo: http://sourceforge.net/projects/dunelegacy/develop
+  repo: https://sourceforge.net/projects/dunelegacy/
   type: remake
   updated: 2012-04-05
   url: http://dunelegacy.sourceforge.net/
@@ -597,15 +589,15 @@
   development: active
   originals:
   - 'Forgotten Realms: Unlimited Adventures'
-  repo: http://uaf.sourceforge.net/download.html
+  repo: https://sourceforge.net/projects/uaf/
   status: playable
   type: remake
   updated: 2016-08-25
-  url: http://uaf.sourceforge.net/index.html
+  url: http://uaf.sourceforge.net/
 
 - name: Dungeon Eye
   images:
-  - http://www.dungeoneye.net/wp-content/uploads/sites/2/2016/05/forest.png
+  - http://www.dungeoneye.net/static/img/screenshots/ingame_001.png
   lang: C#
   development: sporadic
   originals:
@@ -633,7 +625,7 @@
   - DEFCON
   repo: https://github.com/gtanczyk/Dupocracy
   type: clone
-  url: https://github.com/gtanczyk/Dupocracy
+  url: http://gtanczyk.warsztat.io/Dupocracy/game/index.html
 
 - name: DXBall
   framework: Gradle
@@ -648,15 +640,15 @@
 
 - name: DXX-Rebirth
   images:
-  - http://www.dxx-rebirth.com/wp-content/gallery/d1x-rebirth_screenshots/d1xr-scrn10.jpg
-  - http://www.dxx-rebirth.com/wp-content/gallery/d1x-rebirth_screenshots/d1xr-scrn17.jpg
-  - http://www.dxx-rebirth.com/wp-content/gallery/d2x-rebirth_screenshots/d2xr-scrn1.jpg
-  - http://www.dxx-rebirth.com/wp-content/gallery/d2x-rebirth_screenshots/d2xr-scrn18.jpg
+  - https://www.dxx-rebirth.com/wp-content/gallery/d1x-rebirth_screenshots/d1xr-scrn10.jpg
+  - https://www.dxx-rebirth.com/wp-content/gallery/d1x-rebirth_screenshots/d1xr-scrn17.jpg
+  - https://www.dxx-rebirth.com/wp-content/gallery/d2x-rebirth_screenshots/d2xr-scrn1.jpg
+  - https://www.dxx-rebirth.com/wp-content/gallery/d2x-rebirth_screenshots/d2xr-scrn18.jpg
   lang: C
   development: active
   originals:
   - Descent
   - Descent II
-  repo: http://dxx-rebirth.bzr.sourceforge.net/bzr/dxx-rebirth/
+  repo: https://github.com/dxx-rebirth/dxx-rebirth
   type: remake
-  url: http://www.dxx-rebirth.com/
+  url: https://www.dxx-rebirth.com/

--- a/games/e.yaml
+++ b/games/e.yaml
@@ -35,7 +35,7 @@
   development: active
   originals:
   - RPG Maker
-  repo: https://github.com/EasyRPG/
+  repo: https://github.com/EasyRPG/Player
   status: playable
   type: clone
   updated: 2017-10-20
@@ -52,7 +52,7 @@
   development: sporadic
   originals:
   - Eat The Whistle
-  repo: svn://svn.code.sf.net/p/etw/code/trunk
+  repo: https://sourceforge.net/projects/etw/
   type: remake
   updated: 2015-04-10
   url: http://www.ggsoft.org/etw/
@@ -71,23 +71,22 @@
   development: halted
   originals:
   - Wipeout
-  repo: git://git.code.sf.net/p/ecksdee/ecksdee
+  repo: https://sourceforge.net/projects/ecksdee/
   type: clone
   updated: 2015-04-25
-  url: http://sourceforge.net/projects/ecksdee/
 
 - name: ECWolf
   images:
-  - http://maniacsvault.net/ecwolf/ecwolf_fullres.png
+  - https://maniacsvault.net/ecwolf/ecwolf_fullres.png
   lang: C++
   development: active
   originals:
   - Wolfenstein 3D
   - Spear of Destiny
-  repo: https://bitbucket.org/Blzut3/ecwolf
+  repo: https://bitbucket.org/ecwolf/ecwolf
   type: remake
   updated: 2015-04-03
-  url: http://maniacsvault.net/ecwolf/
+  url: https://maniacsvault.net/ecwolf/
 
 - name: EDuke32
   images:
@@ -99,9 +98,9 @@
   development: active
   originals:
   - Duke Nukem 3D
-  repo: http://sourceforge.net/projects/eduke32/develop
+  repo: https://sourceforge.net/projects/eduke32/
   type: remake
-  url: http://eduke32.com/
+  url: https://www.eduke32.com/
 
 - name: EmptyEpsilon
   images:
@@ -120,7 +119,7 @@
   status: playable
   type: remake
   updated: 2016-08-27
-  url: http://daid.github.io/EmptyEpsilon/
+  url: https://daid.github.io/EmptyEpsilon/
 
 - name: encounter
   framework: WebGL
@@ -131,7 +130,7 @@
   repo: https://github.com/air/encounter
   type: remake
   updated: 2015-05-28
-  url: http://air.github.io/encounter/
+  url: https://air.github.io/encounter/
 
 - name: Endless Sky
   images:
@@ -146,7 +145,7 @@
   development: active
   originals:
   - Escape Velocity
-  repo: https://github.com/endless-sky
+  repo: https://github.com/endless-sky/endless-sky
   type: clone
   updated: 2015-05-02
   url: https://endless-sky.github.io/
@@ -162,7 +161,7 @@
   repo: https://github.com/Enigma-Game/Enigma
   type: remake
   updated: 2017-10-20
-  url: http://www.nongnu.org/enigma/
+  url: https://www.nongnu.org/enigma/
 
 - name: Entombed!
   lang: C
@@ -179,10 +178,10 @@
   development: active
   originals:
   - Redneck Rampage
-  repo: https://code.google.com/p/erampage/source/checkout
+  repo: https://code.google.com/archive/p/erampage/
   type: remake
   updated: 2013-05-29
-  url: https://code.google.com/p/erampage/
+  url: https://code.google.com/archive/p/erampage/wikis/MainPage.wiki
 
 - name: Escalade
   lang: Scala
@@ -195,11 +194,6 @@
 
 - name: 'ET: Legacy'
   development: active
-  images:
-  - http://www.splashdamage.com/screens_wet/001.jpg
-  - http://www.splashdamage.com/screens_wet/002.jpg
-  - http://www.splashdamage.com/screens_wet/003.jpg
-  - http://www.splashdamage.com/screens_wet/004.jpg
   lang:
   - C
   - C++
@@ -210,7 +204,7 @@
   repo: https://github.com/etlegacy/etlegacy
   type: remake
   updated: 2013-05-28
-  url: http://etlegacy.com/
+  url: https://www.etlegacy.com/
 
 - name: Executive Man
   images:
@@ -224,6 +218,7 @@
   repo: https://github.com/CamHenlin/ExecutiveMan
   type: remake
   updated: 2015-05-02
+  url: https://henlin.net/ExecutiveMan/
 
 - name: EXILE
   framework: "L\xD6VE"
@@ -236,6 +231,7 @@
   repo: https://github.com/Geti/EXILE
   type: remake
   updated: 2015-06-22
+  url: http://forums.datarealms.com/viewtopic.php?f=82&t=19266
 
 - name: exolon
   images:
@@ -259,7 +255,7 @@
   development: sporadic
   originals:
   - Ultima VII
-  repo: http://sourceforge.net/projects/exult/develop
+  repo: https://sourceforge.net/projects/exult/
   type: remake
   url: http://exult.sourceforge.net/
 
@@ -275,4 +271,4 @@
   repo: https://github.com/ezQuake/ezquake-source
   type: remake
   updated: 2015-07-02
-  url: http://ezquake.sourceforge.net/
+  url: https://ezquake.github.io/

--- a/games/f.yaml
+++ b/games/f.yaml
@@ -4,8 +4,8 @@
   development: sporadic
   originals:
   - Fade to Black
+  repo: https://github.com/cyxx/f2bgl
   type: remake
-  url: https://github.com/cyxx/f2bgl
 
 - name: F-1 Spirit
   framework:
@@ -56,7 +56,7 @@
   status: playable
   type: clone
   updated: 2017-08-29
-  url: http://www.ProjectF.hk/F.LF
+  url: https://www.ProjectF.hk/F.LF
 
 - name: Falling Time
   framework: SDL2
@@ -89,8 +89,8 @@
 - name: Fanwor
   framework: SDL
   images:
-  - http://fanwor.tuxfamily.org/fanwor-1.png
-  - http://fanwor.tuxfamily.org/fanwor-2.png
+  - https://fanwor.tuxfamily.org/fanwor-1.png
+  - https://fanwor.tuxfamily.org/fanwor-2.png
   lang: C
   license:
   - GPL2
@@ -101,7 +101,7 @@
   status: playable
   type: clone
   updated: 2016-03-23
-  url: http://fanwor.tuxfamily.org/
+  url: https://fanwor.tuxfamily.org/
 
 - name: fheroes2
   images:
@@ -111,9 +111,8 @@
   development: active
   originals:
   - Heroes of Might and Magic II
-  repo: http://fheroes2.svn.sourceforge.net/viewvc/fheroes2/
+  repo: https://sourceforge.net/projects/fheroes2/
   type: remake
-  url: http://sourceforge.net/projects/fheroes2/
 
 - name: Fight Or Perish
   images:
@@ -140,31 +139,31 @@
   development: active
   originals:
   - Diablo
-  repo: https://github.com/clintbellanger/flare
+  repo: https://github.com/clintbellanger/flare-game
   type: clone
-  url: http://clintbellanger.net/rpg/
+  url: http://flarerpg.org/
 
 - name: FlightGear
   images:
-  - http://www.flightgear.org/wp-content/gallery/gallery-v2-6/fgfs-screen-029.jpg
-  - http://www.flightgear.org/wp-content/gallery/gallery-v2-6/fgfs-screen-194.jpg
-  - http://www.flightgear.org/wp-content/gallery/gallery-v2-6/fgfs-screen-166.jpg
-  - http://www.flightgear.org/wp-content/gallery/gallery-v2-6/fgfs-screen-019.jpg
+  - https://www.flightgear.org/wp-content/gallery/gallery-v2-6/fgfs-screen-029.jpg
+  - https://www.flightgear.org/wp-content/gallery/gallery-v2-6/fgfs-screen-194.jpg
+  - https://www.flightgear.org/wp-content/gallery/gallery-v2-6/fgfs-screen-166.jpg
+  - https://www.flightgear.org/wp-content/gallery/gallery-v2-6/fgfs-screen-019.jpg
   lang: C++
   development: active
   originals:
   - Microsoft Flight Simulator
-  repo: http://gitorious.org/fg/flightgear
+  repo: https://gitorious.org/fg/flightgear
   type: clone
   updated: 2012-04-05
-  url: http://www.flightgear.org/
+  url: https://home.flightgear.org/
 
 - name: Floor 13
   lang: Ruby
   development: active
   originals:
   - Floor 13
-  repo: https://bitbucket.org/eastmad/floor-13-releases/src
+  repo: https://bitbucket.org/eastmad/floor-13-releases
   type: remake
   updated: 2015-04-03
   url: http://agriculture-and-fisheries.tumblr.com/
@@ -179,7 +178,7 @@
   repo: https://github.com/alexknvl/fonline
   type: remake
   updated: 2016-02-08
-  url: http://fodev.net/
+  url: https://fodev.net/
 
 - name: Football Manager
   license:
@@ -187,10 +186,9 @@
   lang: C
   originals:
   - Football Manager
-  repo: http://www.robsons.org.uk/archive/www.autismuk.freeserve.co.uk/fm-0.99.tar.gz
+  repo: https://github.com/autismuk/Football-Manager
   type: remake
   updated: 2015-04-13
-  url: http://www.robsons.org.uk/archive/www.autismuk.freeserve.co.uk/index.htm
 
 - name: Forge
   lang:
@@ -198,10 +196,10 @@
   development: very active
   originals:
   - 'Magic: The Gathering Online'
-  repo: http://svn.slightlymagic.net/websvn/listing.php?repname=Forge&path=%2F&
+  repo: https://git.cardforge.org/core-developers/forge
   status: playable
   type: clone
-  url: http://www.slightlymagic.net/wiki/Forge
+  url: https://www.slightlymagic.net/wiki/Forge
 
 - name: FQuake3
   lang: F#
@@ -216,18 +214,18 @@
 
 - name: Free Allegiance
   images:
-  - http://www.freeallegiance.org/screenshots/CapitalShips/BelterCapsLaunchTogether.jpg
-  - http://www.freeallegiance.org/screenshots/CapitalShips/ICBattlecruisersResonateAleph.jpg
-  - http://www.freeallegiance.org/screenshots/Dogfights/BigGameVeryBusy.jpg
+  - https://www.freeallegiance.org/screenshots/CapitalShips/BelterCapsLaunchTogether.jpg
+  - https://www.freeallegiance.org/screenshots/CapitalShips/ICBattlecruisersResonateAleph.jpg
+  - https://www.freeallegiance.org/screenshots/Dogfights/BigGameVeryBusy.jpg
   info: Shared source
   lang: C
   development: sporadic
   originals:
   - Allegiance
-  repo: http://freeallegiance.cvs.sourceforge.net/viewvc/freeallegiance/
+  repo: https://github.com/FreeAllegiance/Allegiance
   type: remake
   updated: 2015-04-06
-  url: http://www.freeallegiance.org/
+  url: https://www.freeallegiance.org/
 
 - name: Free in the Dark
   lang: C
@@ -239,16 +237,12 @@
   - Alone in the Dark 2
   - Alone in the Dark 3
   - Jack in the Dark
-  repo: http://fitd.svn.sf.net/viewvc/fitd/trunk/
+  repo: https://sourceforge.net/projects/fitd/
   type: remake
   updated: 2014-09-05
-  url: http://sourceforge.net/projects/fitd/
 
 - name: freeablo
   development: active
-  images:
-  - https://freeablo.org/wp-content/uploads/2014/11/Screenshot-from-2014-11-13-191438.jpg
-  - https://freeablo.org/wp-content/uploads/2014/11/Screenshot-from-2014-11-13-151043.jpg
   lang:
   - C++
   - Python
@@ -261,36 +255,36 @@
   status: playable
   type: remake
   updated: 2014-04-22
-  url: http://freeablo.org/
+  url: https://freeablo.org/
 
 - name: FreeBlocks
   framework: SDL2
   images:
-  - http://i.imgur.com/XDBQy0o.png
-  - http://i.imgur.com/TryDIGI.png
-  - http://i.imgur.com/PysfvNR.png
+  - https://i.imgur.com/XDBQy0o.png
+  - https://i.imgur.com/TryDIGI.png
+  - https://i.imgur.com/PysfvNR.png
   lang: C
   development: halted
   originals:
   - Tetris Attack
+  repo: https://github.com/dorkster/freeblocks
   status: playable
   type: remake
   updated: 2015-02-02
-  url: https://github.com/dorkster/freeblocks
 
 - name: Freeciv
   images:
-  - http://images2.wikia.nocookie.net/__cb20070223045604/freeciv/images/b/b3/Freeciv-2.1.0-beta3-sdl_slack11.0.png
-  - http://images4.wikia.nocookie.net/__cb20061222015333/freeciv/images/9/94/Big_window.png
+  - https://images2.wikia.nocookie.net/__cb20070223045604/freeciv/images/b/b3/Freeciv-2.1.0-beta3-sdl_slack11.0.png
+  - https://images4.wikia.nocookie.net/__cb20061222015333/freeciv/images/9/94/Big_window.png
   lang: C
   license:
   - GPL2
   development: active
   originals:
   - Civilization II
-  repo: http://svn.gna.org/viewcvs/freeciv/
+  repo: https://sourceforge.net/projects/freeciv/
   type: clone
-  url: http://freeciv.wikia.com/
+  url: http://www.freeciv.org/
 
 - name: Freeciv Alpha Centauri project
   images:
@@ -301,7 +295,7 @@
   development: halted
   originals:
   - Sid Meier's Alpha Centauri
-  repo: http://freecivac.cvs.sourceforge.net/viewvc/freecivac/
+  repo: https://sourceforge.net/projects/freecivac/
   type: remake
   updated: 2015-04-11
   url: http://freecivac.sourceforge.net/
@@ -317,34 +311,35 @@
   development: active
   originals:
   - Sid Meier's Colonization
-  repo: https://git.code.sf.net/p/freecol/git
+  repo: https://sourceforge.net/projects/freecol/
   type: remake
   url: http://www.freecol.org/
 
 - name: Freedoom
   development: sporadic
   images:
-  - http://freedoom.github.io/img/screenshots/phase1-0.10_01.png
-  - http://freedoom.github.io/img/screenshots/phase1-0.10_02.png
-  - http://freedoom.github.io/img/screenshots/phase1-0.10_03.png
+  - https://freedoom.github.io/img/screenshots/phase1-0.10_01.png
+  - https://freedoom.github.io/img/screenshots/phase1-0.10_02.png
+  - https://freedoom.github.io/img/screenshots/phase1-0.10_03.png
   content: free
   originals:
   - Doom
   - Doom II
-  repo: https://github.com/chungy/freedoom
+  repo: https://github.com/freedoom/freedoom
   type: remake
   updated: 2013-06-06
-  url: http://freedoom.github.io/
+  url: https://freedoom.github.io/
 
 - name: FreedroidClassic
   images:
-  - http://a.fsdn.com/con/app/proj/freedroid/screenshots/25826.jpg
+  - https://a.fsdn.com/con/app/proj/freedroid/screenshots/25826.jpg
   lang: C
   development: complete
   originals:
   - Paradroid
+  repo: https://gitlab.com/freedroid/freedroid-src
   type: remake
-  url: http://www.freedroid.org/download/#c46
+  url: http://www.freedroid.org/
 
 - name: FreedroidRPG
   images:
@@ -362,6 +357,7 @@
   - Paradroid
   repo: git://git.code.sf.net/p/freedroid/code
   status: playable
+  repo: https://gitlab.com/freedroid/freedroid-src
   type: clone
   url: http://www.freedroid.org/
 
@@ -428,10 +424,10 @@
   development: active
   originals:
   - Warlords II
-  repo: git://git.code.sf.net/p/freelords/git
+  repo: https://gitlab.com/freedroid/freedroid-src
   type: remake
   updated: 2015-04-06
-  url: http://sourceforge.net/projects/freelords/
+  url: https://sourceforge.net/p/freelords/wiki/Home/
 
 - name: Freenukum Jump'n Run
   lang: C
@@ -440,17 +436,16 @@
   development: halted
   originals:
   - Duke Nukem
-  repo: https://bazaar.launchpad.net/~silwol/freenukum/trunk/files
+  repo: https://launchpad.net/freenukum/
   type: remake
   updated: 2015-04-03
-  url: https://launchpad.net/freenukum/
 
 - name: FreeOrion
   development: sporadic
   images:
-  - http://www.freeorion.org/images/8/82/Galaxy_Map_AIs_SVN3100.png
-  - http://www.freeorion.org/images/1/14/Design_Screen_SVN3097.png
-  - http://www.freeorion.org/images/a/ab/FreeOrion3215_Galaxy_Map.png
+  - https://www.freeorion.org/images/8/82/Galaxy_Map_AIs_SVN3100.png
+  - https://www.freeorion.org/images/1/14/Design_Screen_SVN3097.png
+  - https://www.freeorion.org/images/a/ab/FreeOrion3215_Galaxy_Map.png
   lang:
   - C++
   - Python
@@ -463,7 +458,7 @@
   - Master of Orion 2
   repo: https://github.com/freeorion/freeorion
   type: clone
-  url: http://www.freeorion.org/
+  url: https://www.freeorion.org/index.php/Main_Page
 
 - name: FreePrince
   lang: C
@@ -471,9 +466,10 @@
   originals:
   - Prince of Persia
   status: playable
+  repo: http://www.princed.org/downloads/FreePrince/FP_2011-12-04_source.tar.gz
   type: remake
   updated: 2014-01-12
-  url: http://www.princed.org/downloads/FreePrince/FP_2011-12-04_source.tar.gz
+  url: https://www.princed.org/freeprincejsp/
 
 - name: FreeRails
   images:
@@ -484,7 +480,7 @@
   development: halted
   originals:
   - Railroad Tycoon
-  repo: freerails.cvs.sourceforge.net
+  repo: https://sourceforge.net/projects/freerails/
   type: remake
   updated: 2015-04-03
   url: http://freerails.sourceforge.net/
@@ -496,7 +492,7 @@
   development: halted
   originals:
   - Railroad Tycoon
-  repo: svn://svn.code.sf.net/p/freerails2/code/
+  repo: https://sourceforge.net/projects/freerails2/
   type: remake
   updated: 2015-04-03
   url: http://freerails2.sourceforge.net/
@@ -532,7 +528,7 @@
   development: sporadic
   originals:
   - Siege
-  repo: https://github.com/MCMic/freesiege
+  repo: https://gitlab.com/LibreGames/freesiege
   status: playable
   type: remake
   updated: 2013-06-06
@@ -542,9 +538,9 @@
   framework:
   - MonoGame
   images:
-  - http://freeso.org/wp-content/uploads/2016/06/head.bmp
-  - http://freeso.org/wp-content/uploads/2016/01/pool.png
-  - http://freeso.org/wp-content/uploads/2016/01/br.png
+  - https://freeso.org/wp-content/uploads/2016/06/head.bmp
+  - https://freeso.org/wp-content/uploads/2016/01/pool.png
+  - https://freeso.org/wp-content/uploads/2016/01/br.png
   lang:
   - C#
   license:
@@ -556,7 +552,7 @@
   status: playable
   type: remake
   updated: 2016-12-04
-  url: http://freeso.org
+  url: https://freeso.org/
   video:
     youtube: x35aPzAi55M
 
@@ -569,7 +565,7 @@
   development: active
   originals:
   - FreeSpace 2
-  repo: http://svn.icculus.org/fs2open/
+  repo: https://svn.icculus.org/fs2open/
   type: remake
   url: http://scp.indiegames.us/
 
@@ -580,7 +576,7 @@
   development: halted
   originals:
   - Stars!
-  repo: svn://svn.code.sf.net/p/freestars/code/trunk
+  repo: https://sourceforge.net/projects/freestars/
   type: remake
   updated: 2015-04-11
   url: http://freestars.sourceforge.net/
@@ -594,7 +590,7 @@
   development: active
   originals:
   - Syndicate
-  repo: http://freesynd.svn.sourceforge.net/viewvc/freesynd/
+  repo: https://sourceforge.net/projects/freesynd/
   type: remake
   url: http://freesynd.sourceforge.net/
 
@@ -611,7 +607,7 @@
   content: commercial
   originals:
   - A-Train
-  repo: http://sourceforge.net/p/freetrain/code/
+  repo: https://sourceforge.net/projects/freetrain/
   status: playable
   type: clone
   updated: 2018-03-20
@@ -621,17 +617,17 @@
 
 - name: freeVikings
   images:
-  - http://a.fsdn.com/con/app/proj/freevikings/screenshots/186371.jpg
-  - http://a.fsdn.com/con/app/proj/freevikings/screenshots/186373.jpg
-  - http://a.fsdn.com/con/app/proj/freevikings/screenshots/199282.jpg
-  - http://a.fsdn.com/con/app/proj/freevikings/screenshots/186375.jpg
+  - https://a.fsdn.com/con/app/proj/freevikings/screenshots/186371.jpg
+  - https://a.fsdn.com/con/app/proj/freevikings/screenshots/186373.jpg
+  - https://a.fsdn.com/con/app/proj/freevikings/screenshots/199282.jpg
+  - https://a.fsdn.com/con/app/proj/freevikings/screenshots/186375.jpg
   lang: Ruby
   license:
   - GPL2
   development: sporadic
   originals:
   - The Lost Vikings
-  repo: git://git.code.sf.net/p/freevikings/git
+  repo: https://sourceforge.net/projects/freevikings/
   type: clone
   updated: 2015-05-12
   url: http://freevikings.wz.cz/
@@ -645,7 +641,7 @@
   development: halted
   originals:
   - Guitar Hero
-  repo: http://sourceforge.net/p/fretsonfire/code/HEAD/tree/trunk/
+  repo: https://sourceforge.net/projects/fretsonfire/
   status: playable
   type: remake
   updated: 2014-08-20
@@ -670,10 +666,9 @@
   development: halted
   originals:
   - Flying Shark
-  repo: http://friking-shark.googlecode.com/svn/trunk/
+  repo: https://code.google.com/archive/p/friking-shark/
   type: remake
   updated: 2015-04-06
-  url: https://code.google.com/p/friking-shark/
 
 - name: Froggix
   images:
@@ -684,10 +679,9 @@
   development: halted
   originals:
   - Frogger
-  repo: svn://svn.code.sf.net/p/froggix/code/trunk
+  repo: https://sourceforge.net/projects/froggix/
   type: remake
   updated: 2015-04-15
-  url: http://sourceforge.net/projects/froggix/
 
 - name: Frontier 1337
   images:
@@ -706,18 +700,7 @@
   development: sporadic
   originals:
   - Puzzle Bobble
-  repo: http://github.com/kthakore/frozen-bubble
+  repo: https://github.com/kthakore/frozen-bubble
   type: clone
   updated: 2013-06-06
   url: http://frozen-bubble.org/
-
-- name: Full Screen Mario
-  lang: JavaScript
-  development: active
-  originals:
-  - Mario World
-  repo: https://github.com/FullScreenShenanigans/FullScreenMario/
-  status: playable
-  type: remake
-  updated: 2015-04-04
-  url: http://www.fullscreenmario.com/


### PR DESCRIPTION
## Changes

### All
* added repos for projects
* added urls for projects
* use HTTPS when available
* normalized SourceForge links
* updated broken links
* revived dead links using the Wayback Machine

### Project-specific
* **updated Alien 8's url from http://retrospec.sgn.net/game/alien8 to http://retrospec.sgn.net/users/ignacio/a8i.htm, which contains more information**
* **changed Artillery Duel's name to Artillery Duel Reloaded**
* normalized Atomiks's repo url
* changed Babaliba's url to English page
* **removed dead Breakout VR screenshots**
* **changed BRIQUOLO repo link from direct download to downloads page**
* removed duplicate Brutal Chess screenshot
* renamed bstone to BStone
* removed url for CatacombSDL, which was the same as repo
* updated Chocolate Doom's repo from SourceForge to GitHub
* **renamed Colditz Escape! to Colditz Escape**
* updated screenshots for Colditz Escape
* updated repo for Commander Genius
* removed dead Crimson Fields repo
* **removed nonexistent project, Danger Zone**
* changed Deflektor X4's url to a more descriptive page
* updated DGEngine's screencap to one that isn't black for the first couple seconds
* changed Doomsday's repo from SourceForge to GitHub
* fixed and added Dune Dynasty's screenshots
* fixed Dungeon Eye's screenshot
* **changed EasyRPG's repo from https://github.com/EasyRPG to https://github.com/EasyRPG/Player**
* **changed Endless Sky's repo from https://github.com/endless-sky to https://github.com/endless-sky/endless-sky**
* removed dead Et: Legacy screenshots
* removed dead freeablo screenshots
* changed Freeciv's url from the wiki to the main website
* **removed Full Screen Mario, which is unavailable due to a [DMCA takedown](https://github.com/FullScreenShenanigans/FullScreenMario/) ([website](https://www.fullscreenmario.com/))**

The boldened changes are potentially controversial. If there are any changes you disagree with, I will revert those changes.