### PR TITLE
Librelancer License Change

### DIFF
--- a/games/l.yaml
+++ b/games/l.yaml
@@ -246,12 +246,12 @@
   - https://i.imgur.com/xIs46Qz.png
   lang: C#
   license:
-  - MPL
+  - MIT
   development: active
   originals:
   - Freelancer
   type: remake
-  updated: 2016-05-23
+  updated: 2018-10-20
   url: https://github.com/CallumDev/Librelancer
 
 - name: Lincity


### PR DESCRIPTION
Librelancer has now changed to the MIT license. Update file to reflect this