### PR TITLE
Add shell.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ name: [Name, 'http://www.example.com']
 * [Python 2][python]
 * [pipenv][pipenv]
 
+If you use [Nix][nix], you can run `nix-shell` to get a shell with all necessary dependencies.
+
 
 ### Install
 
@@ -113,3 +115,4 @@ See [LICENSE][license]
 
 [python]: https://www.python.org
 [pipenv]: https://pipenv.readthedocs.io/en/latest/
+[nix]: https://nixos.org/nix/

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,19 @@
+with import <nixpkgs> {};
+
+stdenv.mkDerivation {
+  name = "osgameclones";
+  buildInputs = [
+    python27
+    python27Packages.virtualenv
+  ];
+  shellHook = ''
+    export LC_ALL=en_US.UTF-8
+    export LANG=en_US.UTF-8
+    virtualenv --no-setuptools .venv
+    export PATH=$PWD/.venv/bin:$PATH
+    export PIPENV_VENV_IN_PROJECT=1
+    pip install --upgrade pip
+    pip install --upgrade pipenv
+    pipenv sync --dev
+  '';
+}


### PR DESCRIPTION
It's convenient for Nix(OS) users, who only have to run

    nix-shell

to get a sandbox with all dependencies available.