### PR TITLE
Add .venv/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _build/
 .env/
+.venv/
 node_modules/
 *.pyc


### PR DESCRIPTION
It showed up under "Untracked files", and it seems to me that it shouldn't be committed.