### PR TITLE
Dungeon craft: Updated repository

### DIFF
--- a/games/d.yaml
+++ b/games/d.yaml
@@ -681,10 +681,10 @@
   development: active
   originals:
   - 'Forgotten Realms: Unlimited Adventures'
-  repo: https://sourceforge.net/projects/uaf/
+  repo: https://github.com/GaidamakUA/DungeonCraft
   status: playable
   type: remake
-  updated: 2016-08-25
+  updated: 2019-05-07
   url: http://uaf.sourceforge.net/
 
 - name: Dungeon Eye


### PR DESCRIPTION
Replaced old Sourceforge repository with new GitHub one.