### PR TITLE
Add proxx

### DIFF
--- a/games/p.yaml
+++ b/games/p.yaml
@@ -438,6 +438,22 @@
   updated: 2015-04-03
   url: http://quakeone.com/proquake/
 
+- name: proxx
+  development: complete
+  images:
+  - https://user-images.githubusercontent.com/234957/57080494-8caff680-6cea-11e9-8477-54ea0e1670e2.png
+  repo: https://github.com/GoogleChromeLabs/proxx
+  url: https://proxx.app/
+  license:
+  - Apache
+  status: playable
+  framework: WebGL
+  lang: TypeScript
+  originals:
+  - Minesweeper
+  type: clone
+  updated: 2019-06-06
+
 - name: PseuWoW
   images:
   - https://camo.githubusercontent.com/6fc54f5f0ce41476adf68c27e767e9975483cdb0/68747470733a2f2f662e636c6f75642e6769746875622e636f6d2f6173736574732f313130323639352f3235333934332f37633465663061322d386265362d313165322d386166392d3939633063393635663631612e706e67


### PR DESCRIPTION
proxx is a game unveiled at Google I/O which is a Minesweeper clone. It's available for all platforms including desktop and mobile.

A few things I wasn't entirely sure was for "framework", proxx actually allows you to specify different rendering whether it be with WebGL or canvas (see README in repo). I'm not sure if it makes sense to mention both but willing to fix anything if necessary.