### PR TITLE
updates to existing entries, mostly home urls, code repos and license

### DIFF
--- a/games/a.yaml
+++ b/games/a.yaml
@@ -100,10 +100,10 @@
   development: sporadic
   originals:
   - Battle Isle series
-  repo: http://hg.asc-hq.org/hg/asc
+  repo: https://github.com/ValHaris/asc-hq
   status: playable
   type: clone
-  updated: 2014-08-14
+  updated: 2019-08-27
   url: http://www.asc-hq.org/
 
 - name: Afternoon Stalker
@@ -230,7 +230,8 @@
   repo: https://github.com/FreezingMoon/AncientBeast
   status: playable
   type: clone
-  url: https://AncientBeast.com
+  updated: 2019-08-27
+  url: https://ancientbeast.com/
 
 - name: Antares
   images:
@@ -239,14 +240,14 @@
   - https://farm3.static.flickr.com/2597/4103065046_f52a39003f.jpg
   lang: C++
   license:
-  - GPL3
+  - LGPL3
   development: active
   originals:
   - Ares
   repo: https://github.com/arescentral/antares
   status: playable
   type: remake
-  updated: 2014-08-20
+  updated: 2019-08-27
   url: https://arescentral.org/antares/
   video:
     youtube: 4s44qu5zgXE
@@ -364,9 +365,9 @@
   development: active
   originals:
   - AstroMenace
-  repo: https://sourceforge.net/projects/openastromenace/
+  repo: https://github.com/viewizard/astromenace
   type: remake
-  updated: 2015-04-08
+  updated: 2019-08-27
 
 - name: Atari8bit_StarRaiders
   info: reverse engineering project

--- a/games/b.yaml
+++ b/games/b.yaml
@@ -501,4 +501,5 @@
   repo: https://github.com/BZFlag-Dev/bzflag
   status: playable
   type: clone
-  url: https://bzflag.org/
+  updated: 2019-08-27
+  url: https://www.bzflag.org/

--- a/games/c.yaml
+++ b/games/c.yaml
@@ -261,7 +261,7 @@
   - Split-screen
   - Online
   - LAN
-  updated: 2019-08-20
+  updated: 2019-08-27
 
 - name: chainreaction
   lang:
@@ -710,12 +710,12 @@
   lang: C++
   license:
   - GPL2
-  development: sporadic
+  development: halted
   originals:
   - Battle Isle series
   status: playable
   type: clone
-  updated: 2013-05-29
+  updated: 2019-08-27
   url: http://crimson.seul.org/
 
 - name: Crown and Cutlass

--- a/games/d.yaml
+++ b/games/d.yaml
@@ -730,11 +730,12 @@
   lang: C
   license:
   - GPL2
-  development: active
+  development: halted
   originals:
   - Dune 2
   repo: https://sourceforge.net/projects/dunedynasty/
   type: remake
+  updated: 2019-08-27
   url: http://dunedynasty.sourceforge.net/
 
 - name: Dune Legacy

--- a/games/e.yaml
+++ b/games/e.yaml
@@ -321,11 +321,12 @@
   lang: C++
   license:
   - GPL2
-  development: halted
+  development: active
   originals:
   - Ultima VII
-  repo: https://sourceforge.net/projects/exult/
+  repo: https://github.com/exult/exult
   type: remake
+  updated: 2019-08-27
   url: http://exult.sourceforge.net/
 
 - name: ezQuake

--- a/games/f.yaml
+++ b/games/f.yaml
@@ -165,8 +165,8 @@
   - Microsoft Flight Simulator
   repo: https://sourceforge.net/projects/flightgear/
   type: clone
-  updated: 2018-10-05
-  url: https://home.flightgear.org/
+  updated: 2019-08-27
+  url: https://www.flightgear.org/
 
 - name: Fluid Table Tennis
   originals:
@@ -329,8 +329,9 @@
   development: active
   originals:
   - Civilization II
-  repo: https://sourceforge.net/projects/freeciv/
+  repo: https://github.com/freeciv/freeciv
   type: clone
+  updated: 2019-08-27
   url: http://www.freeciv.org/
 
 - name: Freeciv Alpha Centauri project

--- a/games/k.yaml
+++ b/games/k.yaml
@@ -37,8 +37,9 @@
   development: active
   originals:
   - Atomix
-  repo: https://quickgit.kde.org/?p=katomic.git
+  repo: https://cgit.kde.org/katomic.git/
   type: remake
+  updated: 2019-08-27
   url: https://www.kde.org/applications/games/katomic/
 
 - name: Keen Dreams

--- a/games/l.yaml
+++ b/games/l.yaml
@@ -237,8 +237,8 @@
   repo: http://sourceforge.net/p/lgeneral/code/HEAD/tree/trunk/lgeneral/
   status: playable
   type: remake
-  updated: 2013-05-30
-  url: http://lgames.sourceforge.net/index.php?project=LGeneral
+  updated: 2019-08-27
+  url: http://lgames.sourceforge.net/LGeneral/
 
 - name: LibDay
   originals:

--- a/games/m.yaml
+++ b/games/m.yaml
@@ -271,12 +271,12 @@
   lang: JavaScript
   license:
   - GPL3
-  development: halted
+  development: sporadic
   originals:
   - Simcity
   repo: https://github.com/graememcc/micropolisJS
   type: clone
-  updated: 2019-08-17
+  updated: 2019-08-27
   url: http://www.graememcc.co.uk/micropolisJS/
 
 - name: Microracers
@@ -371,7 +371,7 @@
   - C++
   - Lua
   license:
-  - GPL2
+  - LGPL2
   - CC-BY-SA
   content: open
   originals:
@@ -379,7 +379,7 @@
   status: playable
   repo: https://github.com/minetest/minetest
   type: remake
-  updated: 2019-06-07
+  updated: 2019-08-27
   url: https://www.minetest.net/
 
 - name: Mining Haze

--- a/games/n.yaml
+++ b/games/n.yaml
@@ -154,14 +154,14 @@
   - C
   - Lua
   license:
-  - GPL2
+  - GPL3
   development: active
   originals:
   - Larn
-  repo: git://git.code.sf.net/p/nlarn/git nlarn-git
+  repo: https://github.com/nlarn/nlarn
   type: remake
-  updated: 2015-07-12
-  url: http://nlarn.sourceforge.net/
+  updated: 2019-08-27
+  url: https://nlarn.github.io/
 
 - name: Nodes of Yesnod remake
   framework: XNA

--- a/games/o.yaml
+++ b/games/o.yaml
@@ -246,14 +246,14 @@
   - http://opensnc.sourceforge.net/home/screenshots/0_1_3/9.png
   lang: C
   license:
-  - GPL2
+  - GPL3
   development: sporadic
   originals:
   - Sonic the Hedgehog
-  repo: https://sourceforge.net/projects/opensnc/
+  repo: https://github.com/alemart/opensurge
   type: clone
-  updated: 2012-04-05
-  url: http://opensnc.sourceforge.net/home/
+  updated: 2019-08-27
+  url: http://opensurge2d.org/
 
 - name: Open Syobon Action
   lang: C++
@@ -387,8 +387,9 @@
   development: sporadic
   originals:
   - Quake 3
-  repo: http://openarena.ws/svn
+  repo: https://github.com/OpenArena/engine
   type: remake
+  updated: 2019-08-27
   url: http://openarena.ws/
 
 - name: openblack
@@ -474,10 +475,10 @@
   development: active
   originals:
   - Clonk
-  repo: http://git.openclonk.org/openclonk.git/
+  repo: https://github.com/openclonk/openclonk
   type: remake
-  updated: 2012-04-07
-  url: http://www.openclonk.org/
+  updated: 2019-08-27
+  url: https://www.openclonk.org/
   video:
     youtube: zydiZSXpn0w
 
@@ -851,12 +852,13 @@
   - http://www.openlierox.net/official/screenshots/olx6.png
   lang: C++
   license:
-  - GPL2
-  development: active
+  - LGPL2
+  development: sporadic
   originals:
   - Liero
   repo: https://github.com/albertz/openlierox
   type: remake
+  updated: 2019-08-27
   url: http://www.openlierox.net/
 
 - name: OpenLoco

--- a/games/r.yaml
+++ b/games/r.yaml
@@ -431,10 +431,10 @@
   originals:
   - Boulder Dash
   - Supaplex
-  repo: http://git.artsoft.org/?p=rocksndiamonds.git
+  repo: https://git.artsoft.org/rocksndiamonds.git/
   status: playable
   type: remake
-  updated: 2019-08-17
+  updated: 2019-08-27
   url: http://www.artsoft.org/rocksndiamonds/
 
 - name: RPG-X

--- a/games/s.yaml
+++ b/games/s.yaml
@@ -1154,8 +1154,8 @@
   repo: https://github.com/supertuxkart/stk-code
   status: playable
   type: clone
-  updated: 2014-05-08
-  url: http://supertuxkart.sourceforge.net/
+  updated: 2019-08-27
+  url: https://supertuxkart.net/
   video:
     youtube: ev8Zltau4zw
     

--- a/games/t.yaml
+++ b/games/t.yaml
@@ -16,9 +16,9 @@
   originals:
   - Master of Monsters
   - Warsong
-  repo: http://wiki.wesnoth.org/WesnothRepository
+  repo: https://github.com/wesnoth/wesnoth
   type: clone
-  updated: 2016-01-01
+  updated: 2019-08-27
   url: https://www.wesnoth.org/
   video:
     youtube: w3P39lppcH4
@@ -640,9 +640,9 @@
   development: active
   originals:
   - Mad TV
-  repo: https://github.com/GWRon/TVTower
+  repo: https://github.com/TVTower/TVTower
   type: remake
-  updated: 2014-08-16
+  updated: 2019-08-27
   url: http://www.tvgigant.de/en/index
 
 - name: twin-e

--- a/games/u.yaml
+++ b/games/u.yaml
@@ -73,8 +73,8 @@
   - 'UFO: Enemy Unknown'
   repo: https://sourceforge.net/projects/ufoai/
   type: clone
-  url: http://ufoai.ninex.info/
-  updated: 2018-10-06
+  url: https://ufoai.org/wiki/News
+  updated: 2019-08-27
 
 - name: UGH-remake
   lang: C
@@ -191,14 +191,14 @@
 - name: Unvanquished
   lang: C
   license:
-  - GPL2
+  - GPL3
   - CC-BY-SA
   development: active
   originals:
   - Natural Selection
   repo: https://github.com/Unvanquished/Unvanquished
   type: clone
-  updated: 2013-06-08
+  updated: 2019-08-27
   url: http://www.unvanquished.net/
 
 - name: urde

--- a/games/x.yaml
+++ b/games/x.yaml
@@ -42,13 +42,13 @@
   - C
   - C++
   license:
-  - GPL3
+  - GPL2
   development: halted
   originals:
   - 'Archon: The Light and the Dark'
   repo: http://xarchon.seul.org/xarchon-0.50.tar.gz
   type: remake
-  updated: 2015-05-03
+  updated: 2019-08-27
   url: http://xarchon.seul.org/
 
 - name: xBaK


### PR DESCRIPTION
Advanced Strategic Command
- repo is offline for some time, maintainer exported the Mercurial repository recently to Github

Ancient Beast
- home redirects to lowercase URL version

Antares
- code license is LGPL3 (https://arescentral.org/antares: "The latest version of Antares is 0.9.0, released 15 October, 2018. It is licensed under the GNU Lesser General Public License 3.0.")

Astromenace
- code has moved to Github (https://github.com/viewizard/astromenace)

BZFlag
- home redirects to https://www.bzflag.org/ (minor change)

Crimson Fields
- development has halted since many years

Dune Dynasty
- development has halted (no activity since 2016)

Exult
- repo moved to github and there is recent, activity (see https://github.com/exult/exult/graphs/contributors)

FlightGear
- home redirects to https://www.flightgear.org/ (minor change)

Freeciv
- repo moved to github, there is lots of activity (active -> very active)

KAtomic
- repo link outdated, is now at https://cgit.kde.org/katomic.git/

LGeneral
- home link outdatd, is now http://lgames.sourceforge.net/LGeneral/

micropolisJS
- sporadic development, there was a bit of activity in 2018 (see https://github.com/graememcc/micropolisJS/graphs/contributors)

Minetest
- license of source code is LGPL2 (see https://github.com/minetest/minetest/blob/master/LICENSE.txt)

NLarn
- old home url redirects, repo is now on github, license has been upgraded to GPL3

Open Surge
- newer home page, repo moved to github, license has been upgraded to GPL3

OpenArena
- home page redirect, repo moved to github

OpenClonk
- old repo url redirected to github url (replaced with redirect)

OpenLieroX
- license is LGPL2 (see https://github.com/albertz/openlierox/blob/0.59/COPYING.LIB), sporadic development

Rocks'n'Diamonds
- repo url slightly changed

SuperTuxKart
- home url redirects, replaced with redirect

The Battle for Wesnoth
- repo moved to github

TVTower
- repo moved within github

UFO2000
- repo git mirror of svn exists on github, use this

UFO: Alien Invasion
- home url redirects, replace with redirect

Unvanquished
- code license now GPL3 (see https://github.com/Unvanquished/Unvanquished/blob/master/GPL.txt)

XArchon
- code license is GPL2 (see file COPYING in the linked source)

Xonotic
- repo is on gitlab now and license has been upgraded to GPL3 (see https://gitlab.com/xonotic/xonotic/blob/master/COPYING)