### PR TITLE
update Devilution org to diasurgical

### DIFF
--- a/games/d.yaml
+++ b/games/d.yaml
@@ -291,7 +291,7 @@
   development: sporadic
   originals:
   - Diablo
-  repo: https://github.com/galaxyhaxz/devilution
+  repo: https://github.com/diasurgical/devilution
   status: playable
   type: remake
   info: Engine recreation (same bugs as original)
@@ -595,7 +595,7 @@
   type: remake
   updated: 2013-11-20
   url: http://creep.sourceforge.net/
-  
+
 - name: Dreerally
   type: remake
   originals:

--- a/games/d.yaml
+++ b/games/d.yaml
@@ -295,7 +295,7 @@
   status: playable
   type: remake
   info: Engine recreation (same bugs as original)
-  updated: 2019-03-22
+  updated: 2019-11-11
 
 - name: DevilutionX
   type: remake


### PR DESCRIPTION
This also fixes the star count as the main repo has 7.6k stars.

The url listed was the original git repository created by @galaxyhaxz. It has since been moved into the diasurgical GitHub organization to facilitate collaboration.