### PR TITLE
Update KeeperFX URL and add KeeperFX Unofficial

### DIFF
--- a/games/k.yaml
+++ b/games/k.yaml
@@ -90,7 +90,20 @@
   repo: https://github.com/dkfans/keeperfx
   type: remake
   updated: 2017-10-23
-  url: http://keeper.lubiki.pl/html/dk_keeperfx.php
+  url: https://lubiki.keeperklan.com/html/dk_keeperfx.php
+  
+- name: KeeperFX Unofficial
+  lang:
+  - C
+  license:
+  - As-is
+  development: active
+  originals:
+  - Dungeon Keeper
+  repo: https://github.com/Loobinex/keeperfx-unofficial
+  type: remake
+  updated: 2020-05-18
+  url: https://keeperklan.com/threads/6928-KeeperFX-Unofficial-continued-development-alpha-builds
 
 - name: KGoldrunner
   framework:

--- a/games/k.yaml
+++ b/games/k.yaml
@@ -89,7 +89,7 @@
   - Dungeon Keeper
   repo: https://github.com/dkfans/keeperfx
   type: remake
-  updated: 2017-10-23
+  updated: 2020-05-18
   url: https://lubiki.keeperklan.com/html/dk_keeperfx.php
   
 - name: KeeperFX Unofficial


### PR DESCRIPTION
KeeperFX Unofficial is eventually going to be merged upstream into KeeperFX, however I added it as a separate entry for now as it is maintained by different developers.