### PR TITLE
update OpenRCT2 url to the official TLD

### DIFF
--- a/games/o.yaml
+++ b/games/o.yaml
@@ -1407,7 +1407,7 @@
   status: playable
   type: remake
   updated: 2017-10-29
-  url: https://openrct2.com/
+  url: https://openrct2.io/
 
 - name: OpenRoads
   framework:

--- a/games/o.yaml
+++ b/games/o.yaml
@@ -1406,7 +1406,7 @@
   repo: https://github.com/OpenRCT2/OpenRCT2
   status: playable
   type: remake
-  updated: 2017-10-29
+  updated: 2020-5-19
   url: https://openrct2.io/
 
 - name: OpenRoads


### PR DESCRIPTION
The official project's site is the .io TLD.  The .com and .org site is a different project also offering precompiled downloads and an updating launcher for OpenRCT2 from the https://github.com/LRFLEW/OpenRCT2Launcher project.