### PR TITLE
0AD changed from clone to similar to AoE

### DIFF
--- a/games/0.yaml
+++ b/games/0.yaml
@@ -12,7 +12,7 @@
   - Age of Empires
   repo: https://trac.wildfiregames.com/timeline
   status: playable
-  type: clone
+  type: similar
   url: https://play0ad.com/
   feed: http://feeds.feedburner.com/0adrevisions
   multiplayer:


### PR DESCRIPTION
This may end up being controversial, but 0AD is more of an indie game with similar mechanics to AoE rather than an unabashed clone. A "clone" to me would be as faithful as possible to the more popular game but with some minor unique bits (like at most art and engine differences) due to good ol' copyright. Like SuperTux being a Mario clone. 

0AD would be more like an unofficial sequel to AoE rather than an indie remake or something like that. It has a lot of major mechanical gameplay changes (most notably, soldiers are also workers), and doesn't at all try to market itself as a clone of AoE, but rather at most as a game that builds on the concepts of AoE. At most, the game is more of a clone (and even this is wrong imo) of AoE 2, as it started as a mod for that game.

I do think it's very similar and of the same genre, I just think it's not a clone. It's certainly less of one than Star Wars Galactic Battlegrounds was for AoE, ironically. :P

But why does my opinion, of one who never even contributed anything to here before, matter that much? :P