### PR TITLE
Add ZZT/Super ZZT remakes and tools

### DIFF
--- a/games/d.yaml
+++ b/games/d.yaml
@@ -669,6 +669,19 @@
   updated: 2013-11-20
   url: http://creep.sourceforge.net/
 
+- name: DreamZZT
+  type: remake
+  originals:
+  - ZZT
+  repo: https://github.com/c99koder/DreamZZT
+  development: halted
+  status: semi-playable
+  lang:
+  - C++
+  license:
+  - GPL2
+  updated: 2020-06-26
+
 - name: Dreerally
   type: remake
   originals:

--- a/games/k.yaml
+++ b/games/k.yaml
@@ -92,6 +92,30 @@
   updated: 2017-10-23
   url: http://keeper.lubiki.pl/html/dk_keeperfx.php
 
+- name: KevEdit
+  type: tool
+  originals:
+  - ZZT
+  repo: https://github.com/cknave/kevedit
+  development: sporadic
+  status: playable
+  lang:
+  - C
+  framework:
+  - SDL2
+  license:
+  - GPL2
+  info: Advanced world editor
+  updated: 2020-06-26
+  images:
+  - https://cloud.githubusercontent.com/assets/4196901/22183137/b51c68e6-e084-11e6-874d-3458041f4308.gif
+  - https://cloud.githubusercontent.com/assets/4196901/22183135/b515754a-e084-11e6-9fe3-2483eb67ca79.gif
+  - https://cloud.githubusercontent.com/assets/4196901/22183134/b514af02-e084-11e6-9ca7-7b21bedb479d.gif
+  - https://cloud.githubusercontent.com/assets/4196901/22183131/b5142230-e084-11e6-95c1-19133c677388.gif
+  - https://cloud.githubusercontent.com/assets/4196901/22183132/b5142208-e084-11e6-8ab1-568d217391ec.gif
+  - https://cloud.githubusercontent.com/assets/4196901/22183133/b51426b8-e084-11e6-8ce7-e01b7d6a06ed.gif
+  - https://cloud.githubusercontent.com/assets/4196901/22183136/b516dd4a-e084-11e6-8e9b-30201734480a.gif
+
 - name: KGoldrunner
   framework:
   - SDL2

--- a/games/l.yaml
+++ b/games/l.yaml
@@ -558,3 +558,19 @@
   repo: https://github.com/kaikai2/luminesk5
   type: remake
   updated: 2015-04-13
+
+- name: Lyon
+  type: remake
+  originals:
+  - Super ZZT
+  - ZZT
+  repo: https://github.com/SaxxonPike/roton
+  development: halted
+  status: playable
+  lang:
+  - C#
+  license:
+  - ISC
+  updated: 2020-06-26
+  video:
+    youtube: foy-KsLk7Vk

--- a/games/r.yaml
+++ b/games/r.yaml
@@ -118,6 +118,34 @@
   type: remake
   updated: 2015-07-29
 
+- name: Reconstruction of Super ZZT
+  type: remake
+  originals:
+  - Super ZZT
+  repo: https://github.com/asiekierka/reconstruction-of-super-zzt
+  development: complete
+  status: playable
+  lang:
+  - Pascal
+  license:
+  - MIT
+  info: Binary-accurate source code reconstruction
+  updated: 2020-06-26
+
+- name: Reconstruction of ZZT
+  type: remake
+  originals:
+  - ZZT
+  repo: https://github.com/asiekierka/reconstruction-of-zzt
+  development: complete
+  status: playable
+  lang:
+  - Pascal
+  license:
+  - MIT
+  info: Binary-accurate source code reconstruction
+  updated: 2020-06-26
+
 - name: RedneckGDX
   originals:
   - Redneck Rampage
@@ -674,6 +702,23 @@
   type: clone
   updated: 2015-04-26
   url: http://sourceforge.net/projects/therush/
+
+- name: RuZZT
+  type: remake
+  originals:
+  - ZZT
+  repo: https://github.com/yokljo/ruzzt
+  development: halted
+  status: playable
+  lang:
+  - Rust
+  framework:
+  - SDL2
+  license:
+  - MIT
+  updated: 2020-06-26
+  images:
+  - https://raw.githubusercontent.com/yokljo/ruzzt/master/screenshot.png
 
 - name: RxWars
   lang:

--- a/games/t.yaml
+++ b/games/t.yaml
@@ -688,6 +688,24 @@
   updated: 2017-10-23
   url: https://github.com/xesf/twin-e
 
+- name: Tyger
+  type: remake
+  originals:
+  - ZZT
+  repo: https://code.google.com/archive/p/tyger/
+  development: halted
+  status: semi-playable
+  lang:
+  - Python
+  framework:
+  - pygame
+  license:
+  - MIT
+  updated: 2020-06-26
+  images:
+  - http://zzt.org/dr_dos/tyger/TygerTitle.png
+  - http://zzt.org/dr_dos/tyger/TOWN-25.png
+
 - name: TypeScript Xenon
   type: remake
   originals:

--- a/games/z.yaml
+++ b/games/z.yaml
@@ -155,6 +155,24 @@
     youtube: dyhzqcf7NJM
   updated: 2019-10-21
 
+- name: Zeta
+  type: tool
+  originals:
+  - ZZT
+  - Super ZZT
+  repo: https://github.com/asiekierka/zeta
+  url: https://zeta.asie.pl/
+  development: complete
+  status: playable
+  lang:
+  - C
+  framework:
+  - SDL2
+  license:
+  - MIT
+  info: Dedicated emulator
+  updated: 2020-06-26
+
 - name: Zod Engine
   images:
   - http://zod.sourceforge.net/screenshots/gameplay_13.png
@@ -226,3 +244,16 @@
   url: http://zsilencer.com/
   video:
     youtube: mojUQUONp4M
+
+- name: zztgo
+  type: remake
+  originals:
+  - ZZT
+  repo: https://github.com/benhoyt/zztgo
+  development: halted
+  status: semi-playable
+  lang:
+  - Go
+  license:
+  - MIT
+  updated: 2020-06-26

--- a/originals/s.yaml
+++ b/originals/s.yaml
@@ -817,5 +817,7 @@
   - DOS
   meta:
     genre:
+    - Action
     - Adventure
+    - Puzzle
 

--- a/originals/s.yaml
+++ b/originals/s.yaml
@@ -809,3 +809,13 @@
     genre:
       - Action
       - Adventure
+
+- name: Super ZZT
+  external:
+    wikipedia: ZZT
+  platform:
+  - DOS
+  meta:
+    genre:
+    - Adventure
+

--- a/originals/z.yaml
+++ b/originals/z.yaml
@@ -43,3 +43,11 @@
     genre:
     - Puzzle
 
+- name: ZZT
+  external:
+    wikipedia: ZZT
+  platform:
+  - DOS
+  meta:
+    genre:
+    - Adventure

--- a/originals/z.yaml
+++ b/originals/z.yaml
@@ -50,4 +50,6 @@
   - DOS
   meta:
     genre:
+    - Action
     - Adventure
+    - Puzzle


### PR DESCRIPTION
> Tyger's repo is Google Code, a dead service. Please check if there is an updated repo elsewhere.

None such, the project was abandoned a decade ago. (It is, however, the only Python-based remake)

Most of the other projects (Reconstructions, Zeta, and the Reconstruction-based zztgo) are indistinguishable from the original game "in play".