### PR TITLE
Updated Vega Strike: in active development again

### DIFF
--- a/games/v.yaml
+++ b/games/v.yaml
@@ -97,10 +97,10 @@
   type: similar
   originals:
   - Elite
-  repo: https://sourceforge.net/projects/vegastrike/
+  repo: https://github.com/vegastrike/Vega-Strike-Engine-Source/
   url: http://vegastrike.sourceforge.net/
   feed: http://vegastrike.sourceforge.net/svnlog/svn_log.rss
-  development: halted
+  development: active
   status: playable
   lang:
   - C
@@ -110,7 +110,7 @@
   license:
   - GPL2
   content: open
-  updated: 2019-09-17
+  updated: 2020-02-16
   images:
   - http://vegastrike.sourceforge.net/forums/cpg/albums/user_screenshots/normal_lazer_rain_redux.jpg
   - http://vegastrike.sourceforge.net/forums/cpg/albums/vs_screenshots/normal_starting_system_fighterbase.jpg

--- a/games/v.yaml
+++ b/games/v.yaml
@@ -99,7 +99,7 @@
   - Elite
   repo: https://github.com/vegastrike/Vega-Strike-Engine-Source/
   url: https://www.vega-strike.org
-  feed: http://vegastrike.sourceforge.net/svnlog/svn_log.rss
+  feed: https://www.vega-strike.org/feed.xml
   development: active
   status: playable
   lang:

--- a/games/v.yaml
+++ b/games/v.yaml
@@ -98,7 +98,7 @@
   originals:
   - Elite
   repo: https://github.com/vegastrike/Vega-Strike-Engine-Source/
-  url: http://vegastrike.sourceforge.net/
+  url: https://www.vega-strike.org
   feed: http://vegastrike.sourceforge.net/svnlog/svn_log.rss
   development: active
   status: playable

--- a/games/v.yaml
+++ b/games/v.yaml
@@ -103,7 +103,6 @@
   development: active
   status: playable
   lang:
-  - C
   - C++
   framework:
   - OpenGL

--- a/games/v.yaml
+++ b/games/v.yaml
@@ -108,7 +108,7 @@
   framework:
   - OpenGL
   license:
-  - GPL2
+  - GPL3
   content: open
   updated: 2020-02-16
   images:


### PR DESCRIPTION
Updated the repo info as well. Using latest release as the updated date:
https://github.com/vegastrike/Vega-Strike-Engine-Source/releases/tag/0.5.3