### PR TITLE
Adds Vanilla-Conquer project.

### DIFF
--- a/games/c.yaml
+++ b/games/c.yaml
@@ -403,13 +403,13 @@
   - C++
   license:
   - GPL2
-  development: active
+  development: halted
   originals:
   - 'Command & Conquer: Red Alert'
   repo: https://github.com/TheAssemblyArmada/Chronoshift
   type: remake
   status: playable
-  updated: 2018-11-02
+  updated: 2020-07-22
 
 - name: Circus Linux!
   images:

--- a/games/v.yaml
+++ b/games/v.yaml
@@ -19,6 +19,23 @@
   framework:
   - NeoAxis Engine
 
+- name: Vanilla-Conquer
+  lang:
+  - C
+  - C++
+  - Assembly
+  license:
+  - GPL3
+  development: active
+  originals:
+  - 'Command & Conquer'
+  - 'Command & Conquer: Red Alert'
+  info: VanillaConquer is based on the open sourced code for the Command & Conquer Remaster and can play the original games content standalone.
+  repo: https://github.com/Vanilla-Conquer/Vanilla-Conquer
+  type: remake
+  status: playable
+  updated: 2020-07-22
+
 - name: VASSAL
   images:
   - http://www.vassalengine.org/images/screenshot1.png


### PR DESCRIPTION
Adds remake project for Command and Conquer and Red Alert based on the source code released for the remaster games. Also changes status of the Chronoshift project to halted since the source code released rendered further development of marginal benefit.