### PR TITLE
Fixing text filtering hides originals

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -72,9 +72,12 @@ function filter(filter_value) {
   for (var i = 0, l = nodes.length; i < l; i++) {
     var el = nodes[i], next = el, index = [];
     while ((next = next.nextElementSibling) && !next.id) {
-      if (next.tagName != 'DD')
+      if (next.tagName != 'DIV')
         continue;
-      index.push(next.getAttribute('data-index'));
+      var childs = next.children;
+      for (var child of childs) {
+        index.push(child.getAttribute('data-index'));
+      }
     }
     el.setAttribute('data-index', index.join(' '));
   };


### PR DESCRIPTION
Fixing #1131 
The schema.org itemscope divs broke the data-index collection, because the DTs next sibling now DIVs and not DDs