### PR TITLE
Separate pages for games

### DIFF
--- a/.cyrax.cfg
+++ b/.cyrax.cfg
@@ -1,2 +1,0 @@
-sitecallback: _ext.callback
-exclude: [games/*, originals/*, schema/*, templates/*, Makefile, README.md, requirements.txt, Dockerfile, vhost.conf, CHECKS, Pipfile*, LICENSE, dangerfile.js, package.json, yarn.lock, bunny-sync, node_modules/*]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN apk add --no-cache python3 py3-yaml && \
     pip3 --disable-pip-version-check install pipenv && \
     pipenv install
 RUN env
-RUN pipenv run cyrax /src -d /www && pipenv run htmlmin /www/index.html /www/index.html
+RUN pipenv run /src/render.py -d /www && pipenv run htmlmin /www/index.html /www/index.html

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 run:
-	cyrax
+	pipenv run ./render.py
 
 prod:
-	cyrax && htmlmin _build/index.html _build/index.html
+	./render.py && htmlmin _build/index.html _build/index.html

--- a/Pipfile
+++ b/Pipfile
@@ -4,12 +4,12 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-cyrax = ">=3.1"
 natsort = "*"
 pykwalify = ">=1.6.1"
 PyYAML = "*"
 Unidecode = "*"
 htmlmin = "*"
+jinja2 = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c5dca4d3591343b5e9665ca16ece92965c5f9c5be295b364accf69a5e406413e"
+            "sha256": "f8ea9fff863200d08944a402df3fcf81ba20b228a205df8e066b5340735eed09"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,13 +16,6 @@
         ]
     },
     "default": {
-        "cyrax": {
-            "hashes": [
-                "sha256:03090aae4d74d486b7d801b9b96e61810331db36310935fed439a3c55dd473b0"
-            ],
-            "index": "pypi",
-            "version": "==3.1"
-        },
         "docopt": {
             "hashes": [
                 "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
@@ -38,17 +31,11 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:93187ffbc7808079673ef52771baa950426fd664d3aad1d0fa3e95644360e250",
-                "sha256:b0eaf100007721b5c16c1fc1eecb87409464edc10469ddc9a22a27a99123be49"
+                "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
+                "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
             ],
-            "version": "==2.11.1"
-        },
-        "markdown2": {
-            "hashes": [
-                "sha256:7ff88e00b396c02c8e1ecd8d176cfa418fb01fe81234dcea77803e7ce4f05dbe",
-                "sha256:882d3607fc023cdea0ac2cd0e1147617fcb0361cb1133d3ff095417f995ff270"
-            ],
-            "version": "==2.3.8"
+            "index": "pypi",
+            "version": "==2.11.2"
         },
         "markupsafe": {
             "hashes": [
@@ -86,6 +73,7 @@
                 "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
                 "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
         },
         "natsort": {
@@ -109,6 +97,7 @@
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
                 "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.1"
         },
         "pyyaml": {
@@ -130,16 +119,11 @@
         },
         "six": {
             "hashes": [
-                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
-                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "version": "==1.14.0"
-        },
-        "smartypants": {
-            "hashes": [
-                "sha256:8db97f7cbdf08d15b158a86037cd9e116b4cf37703d24e0419a0d64ca5808f0d"
-            ],
-            "version": "==2.0.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.15.0"
         },
         "unidecode": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ pipenv install
 Simply run the following to build the project into the `_build` directory.
 
 ```
-pipenv run cyrax
+make
 ```
 
 ## License

--- a/_ext.py
+++ b/_ext.py
@@ -8,7 +8,6 @@ from functools import partial
 from urllib.parse import urlparse
 
 import yaml
-from cyrax import events
 from natsort import natsorted, ns
 from pykwalify.core import Core
 
@@ -286,7 +285,3 @@ def parse_data(site):
             if name in clone['originals']
         ]
         parse_items(site, combined, 'games')
-
-
-def callback(site):
-    events.events.connect('traverse-started', parse_data)

--- a/game.html
+++ b/game.html
@@ -1,0 +1,11 @@
+{%- import 'templates/common.html' as common with context %}
+{%- import 'templates/games.html' as games with context %}
+
+{{- common.head() }}
+{{ common.nav() }}
+
+<main class="single">
+  {{ games.render(game[0], game[1], game[2], 'game') }}
+</main>
+
+{{ common.footer() -}}

--- a/index.html
+++ b/index.html
@@ -1,141 +1,48 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="author" content="Vsevolod Solovyov">
-  <meta name="keywords" content="open source, game, clone, remake, remakes">
-  <meta name="description" content="List of open source clones and remakes of popular old-school games.">
-  <meta name="application-name" content="OS Game Clones">
-  <meta name="application-url" content="http://osgameclones.com/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="canonical" href=".">
-  <link rel="stylesheet" href="static/main.css">
-  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.12.1/css/all.css" integrity="sha384-v8BU367qNbs/aIZIxuivaU55N5GPF89WBerHoGA4QTcbUjYiLQtKdrfXnqAcXyTv" crossorigin="anonymous">
-  <title>Open Source Game Clones</title>
-</head>
+{%- import 'templates/common.html' as common with context %}
+{%- import 'templates/games.html' as games with context %}
 
-{% import 'templates/tags.html' as tags %}
-{% import 'templates/video.html' as video %}
-{% import 'templates/games.html' as games with context %}
+{{- common.head() }}
+{{ common.nav() }}
 
-<body>
-  <script type="text/javascript" src="static/startInDarkMode.js"></script>
+<article>
+  <h1>Open Source Game Clones</h1>
 
-  <header>
-    <div class="container">
-      <input id="filter" type="search" placeholder="Type to filter">
+  <p>
+    This site tries to gather <a href="http://en.wikipedia.org/wiki/Open_source">open-source</a>
+    remakes of great old games in one place. If you think that
+    something is missing from the list - please go to
+    our <a href="http://github.com/opengaming/osgameclones/">GitHub
+    repository</a> and create an issue or even a pull request!
+  </p>
+  <p>
+    Since all these projects are open-source you can help them and make this
+    world a better place. Or at least you can play something to appreciate the
+    effort people put in them.
+  </p>
+  <p>
+    Similar resources: check
+    out <a href="http://freegamer.blogspot.com/">Free Gamer</a>, a blog
+    dedicated to open source game news, and <a href="https://bronevichok.ru/ttygames/">Unix ASCII games</a>, a list of opensource text-based games.
+  </p>
+</article>
 
-      <ul id="nav">
-        <li>
-          <span class="nav-btn">Languages</span>
-          <div class="tag-group">
-            <div class="container">
-            {% for tag, tag_props in site.lang.items() %}
-              {{ tags.render_tag('lang', tag, tag_props['tag_count']) }}
-            {% endfor %}
-            </div>
-          </div>
-        </li>
-
-        <li>
-          <span class="nav-btn">Genres</span>
-          <div class="tag-group">
-            <div class="container">
-            {% for tag, tag_props in site.genre.items() %}
-              {{ tags.render_tag('genre', tag, tag_props['tag_count']) }}
-            {% endfor %}
-            </div>
-          </div>
-        </li>
-
-        <li>
-          <span class="nav-btn">Subgenres</span>
-          <div class="tag-group">
-            <div class="container">
-            {% for tag, tag_props in site.subgenre.items() %}
-              {{ tags.render_tag('subgenre', tag, tag_props['tag_count']) }}
-            {% endfor %}
-            </div>
-          </div>
-        </li>
-
-        <li>
-          <span class="nav-btn">Themes</span>
-          <div class="tag-group">
-            <div class="container">
-            {% for tag, tag_props in site.theme.items() %}
-              {{ tags.render_tag('theme', tag, tag_props['tag_count']) }}
-            {% endfor %}
-            </div>
-          </div>
-        </li>
-
-        <li>
-          <span class="nav-count">xxxx/yyyy games</span>
-        </li>
-      </ul>
-      <span id='darkThemeButton' class="nav-btn">Dark Theme</span>
-      <span id='sortButton' class="nav-btn">Sort by ........</span>
-    </div>
-  </header>
-
+<div id="content">
+  <h2>List of games</h2>
   <article>
-    <h1>Open Source Game Clones</h1>
-
-    <p>
-      This site tries to gather <a href="http://en.wikipedia.org/wiki/Open_source">open-source</a>
-      remakes of great old games in one place. If you think that
-      something is missing from the list - please go to
-      our <a href="http://github.com/opengaming/osgameclones/">GitHub
-      repository</a> and create an issue or even a pull request!
-    </p>
-    <p>
-      Since all these projects are open-source you can help them and make this
-      world a better place. Or at least you can play something to appreciate the
-      effort people put in them.
-    </p>
-    <p>
-      Similar resources:
-      <ul>
-        <li><a href="https://freegamer.blogspot.com">Free Gamer</a>, a blog dedicated to open source game news</li>
-        <li><a href="https://bronevichok.ru/ttygames/">Unix ASCII games</a>, a list of opensource text-based games</li>
-        <li><a href="https://trilarion.github.io/opensourcegames/">List of Open Source Games</a>, list of open source games in mature/beta state</li>
-        <li><a href="https://github.com/leereilly/games">Games on GitHub</a>, list of open source games and game-related projects that can be found on GitHub</li>
-        <li><a href="https://libregamewiki.org/Main_Page">LibreGameWiki</a>, the free gaming encyclopedia</li>
-      </ul>
-    </p>
+    A <span class="tag type" data-name="remake">Remake</span> is a game where the executable and sometimes the assets as well are remade open source. Some of these games aren&#39;t exact remakes but evolution of original ones, which were eventually open sourced.
+    <br />
+    A <span class="tag type" data-name="clone">Clone</span> is a game which is very similar to or heavily inspired by a game or series.
+    <br />
+    A <span class="tag type" data-name="similar">Similar</span> game is one which has similar gameplay but is not a clone.
+    <br />
+    A <span class="tag type" data-name="tool">Tool</span> is not a game, but something that assists in playing or modding the game, such as a high resolution patch, or resource extractor.
   </article>
+  <dl id="list">
+    {% for names, meta, items in site.games %}
+      {{ games.render(names, meta, items, 'games') }}
+    {% endfor %}
+  </dl>
+  <dl id="sorted"></dl>
+</div>
 
-  <div id="content">
-    <h2>List of games</h2>
-    <article>
-      A <span class="tag type" data-name="remake">Remake</span> is a game where the executable and sometimes the assets as well are remade open source. Some of these games aren&#39;t exact remakes but evolution of original ones, which were eventually open sourced.
-      <br />
-      A <span class="tag type" data-name="clone">Clone</span> is a game which is very similar to or heavily inspired by a game or series.
-      <br />
-      A <span class="tag type" data-name="similar">Similar</span> game is one which has similar gameplay but is not a clone.
-      <br />
-      A <span class="tag type" data-name="tool">Tool</span> is not a game, but something that assists in playing or modding the game, such as a high resolution patch, or resource extractor.
-    </article>
-    <dl id="list">
-      {% for names, meta, items in site.games %}
-        {{ games.render(names, meta, items, 'games') }}
-      {% endfor %}
-    </dl>
-    <dl id="sorted"></dl>
-  </div>
-
-  <footer>&#169; 2011-2020
-    <a href="mailto:vsevolod.solovyov@gmail.com">Vsevolod Solovyov</a>,
-    <a href="mailto:alexander@solovyov.net">Alexander Solovyov</a>,
-    <a href="https://github.com/opengaming/osgameclones/graphs/contributors">and other contributors.</a>
-  </footer>
-
-  <style id="filter-style"></style>
-  <style id="tag-style"></style>
-
-  <script type="text/javascript" src="static/main.js" async></script>
-
-  <script data-goatcounter="https://osgc.goatcounter.com/count" src="//gc.zgo.at/count.js" async></script>
-</body>
-</html>
+{{ common.footer() -}}

--- a/render.py
+++ b/render.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+import os, os.path as op
+import shutil
+import functools
+import argparse
+import logging
+import re
+
+import jinja2
+import _ext
+
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger()
+
+
+DIR = op.dirname(__file__)
+
+
+class Site:
+    pass
+
+
+@functools.lru_cache(10)
+def env():
+    return jinja2.Environment(loader=jinja2.FileSystemLoader(DIR))
+
+
+@functools.lru_cache(10)
+def ctx():
+    site = Site()
+    _ext.parse_data(site)
+    return site
+
+
+def slug(s):
+    return re.sub(r'[^a-z0-9]+', '-', s.lower()).strip('-')
+
+
+def render_to(src, dst, **ctx):
+    t = env().get_template(src)
+
+    log.info(f'Rendering {src} -> {dst}')
+    res = t.render(**ctx)
+
+    os.makedirs(op.dirname(dst), exist_ok=True)
+    with open(dst, 'w') as f:
+        f.write(res)
+
+
+def copy_to(src, dst):
+    log.info(f'Copying {src} -> {dst}')
+    shutil.copytree(src, dst)
+
+
+def render_all(target):
+    if op.exists(target):
+        shutil.rmtree(target)
+
+    copy_to('static', target + '/static')
+
+    site = ctx()
+    render_to('index.html', f'{target}/index.html', site=site)
+    for game in ctx().games:
+        name = slug(game[0][0])
+        render_to('game.html', f'{target}/{name}/index.html', site=site, game=game)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Render OSGC')
+    parser.add_argument('-d', '--dest', default='_build')
+    args = parser.parse_args()
+
+    render_all(args.dest)
+
+
+if __name__ == '__main__':
+    main()

--- a/templates/common.html
+++ b/templates/common.html
@@ -1,0 +1,99 @@
+{% import 'templates/tags.html' as tags %}
+
+{% macro head(title, keywords, description) -%}
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="author" content="Open Gaming Collective">
+    <meta name="keywords" content="{{ keywords|default('open source, game, clone, remake, remakes', true) }}">
+    <meta name="description" content="{{ description|default('List of open source clones and remakes of popular old-school games.', true) }}">
+    <meta name="application-name" content="OS Game Clones">
+    <meta name="application-url" content="http://osgameclones.com/">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="/static/main.css">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.12.1/css/all.css" integrity="sha384-v8BU367qNbs/aIZIxuivaU55N5GPF89WBerHoGA4QTcbUjYiLQtKdrfXnqAcXyTv" crossorigin="anonymous">
+    <title>{{ title|default('Open Source Game Clones', true) }}</title>
+  </head>
+
+  <body>
+    <script type="text/javascript" src="/static/startInDarkMode.js"></script>
+{%- endmacro %}
+
+
+{% macro footer() -%}
+    <footer>&#169; 2011-2020
+      <a href="mailto:vsevolod.solovyov@gmail.com">Vsevolod Solovyov</a>,
+      <a href="mailto:alexander@solovyov.net">Alexander Solovyov</a>,
+      <a href="https://github.com/opengaming/osgameclones/graphs/contributors">and other contributors.</a>
+    </footer>
+
+    <style id="filter-style"></style>
+    <style id="tag-style"></style>
+    <script type="text/javascript" src="/static/main.js" async></script>
+
+    <script data-goatcounter="https://osgc.goatcounter.com/count" src="//gc.zgo.at/count.js" async></script>
+  </body>
+</html>
+{%- endmacro %}
+
+
+{% macro nav() -%}
+<header>
+  <div class="container">
+    <input id="filter" type="search" placeholder="Type to filter">
+
+    <ul id="nav">
+      <li>
+        <span class="nav-btn">Languages</span>
+        <div class="tag-group">
+          <div class="container">
+            {% for tag, tag_props in site.lang.items() %}
+            {{ tags.render_tag('lang', tag, tag_props['tag_count']) }}
+            {% endfor %}
+          </div>
+        </div>
+      </li>
+
+      <li>
+        <span class="nav-btn">Genres</span>
+        <div class="tag-group">
+          <div class="container">
+            {% for tag, tag_props in site.genre.items() %}
+            {{ tags.render_tag('genre', tag, tag_props['tag_count']) }}
+            {% endfor %}
+          </div>
+        </div>
+      </li>
+
+      <li>
+        <span class="nav-btn">Subgenres</span>
+        <div class="tag-group">
+          <div class="container">
+            {% for tag, tag_props in site.subgenre.items() %}
+            {{ tags.render_tag('subgenre', tag, tag_props['tag_count']) }}
+            {% endfor %}
+          </div>
+        </div>
+      </li>
+
+      <li>
+        <span class="nav-btn">Themes</span>
+        <div class="tag-group">
+          <div class="container">
+            {% for tag, tag_props in site.theme.items() %}
+            {{ tags.render_tag('theme', tag, tag_props['tag_count']) }}
+            {% endfor %}
+          </div>
+        </div>
+      </li>
+
+      <li>
+        <span class="nav-count">xxxx/yyyy games</span>
+      </li>
+    </ul>
+    <span id='darkThemeButton' class="nav-btn">Dark Theme</span>
+    <span id='sortButton' class="nav-btn">Sort by ........</span>
+  </div>
+</header>
+{%- endmacro %}

--- a/templates/games.html
+++ b/templates/games.html
@@ -1,3 +1,6 @@
+{% import 'templates/video.html' as video %}
+{% import 'templates/tags.html' as tags %}
+
 {% macro render_name(name, meta, idx, mode) %}
   {%- if meta['external']['wikipedia'] -%}
     {% set wikilink = "http://en.wikipedia.org/wiki/" + meta['external']['wikipedia'] %}


### PR DESCRIPTION
So the idea is the following: Google really likes pages dedicated to a single topic. If we get those, it'll bring more traffic to site, in turn driving traffic to those games (and showing that there are a lot of them), which sounds like a good thing. 

Also the main page is really big right now, and Google complains about that. :)

This pull request contains a script (`render.py`) which seems to be doing everything we need from site generator - this allows to drop Cyrax as a dependency and be more flexible. It generates index.html and then a separate page for each game (or group of games). It's not very pretty right now - it's the same markup as for a game entry in a common list, and I think it could be better/bigger/etc:

![image](https://user-images.githubusercontent.com/6553/95735755-eeb9ad00-0c8d-11eb-868f-c4f0bd5cad26.png)


After that we could put a link to those games and see for some time if it will change Google's results. In theory Google should start driving more traffic to an individual game page.

We could also generate pages for genres etc, there is some search traffic there, like that:

![image](https://user-images.githubusercontent.com/6553/95735646-c2059580-0c8d-11eb-9a4f-ad476bd63431.png)
