### PR TITLE
Micropolis is a remake, not a clone

### DIFF
--- a/games/m.yaml
+++ b/games/m.yaml
@@ -314,7 +314,7 @@
   originals:
   - Simcity
   repo: https://github.com/SimHacker/micropolis
-  type: clone
+  type: remake
   updated: 2013-05-27
 
 - name: micropolisJS
@@ -326,7 +326,7 @@
   originals:
   - Simcity
   repo: https://github.com/graememcc/micropolisJS
-  type: clone
+  type: remake
   updated: 2019-08-27
   url: http://www.graememcc.co.uk/micropolisJS/
 


### PR DESCRIPTION
Micropolis is actually based on the original Unix version of SimCity, and had its name changed for copyright reasons only.