### PR TITLE
Fixed the GTA2.NET URL as it was referencing a copy.

### DIFF
--- a/games/g.yaml
+++ b/games/g.yaml
@@ -453,8 +453,8 @@
   originals:
   - Grand Theft Auto 2
   type: remake
-  updated: 2018-10-05
-  url: https://github.com/andrecarlucci/gta2net
+  updated: 2021-01-30
+  url: https://code.google.com/archive/p/gta2net/
 
 - name: GUSANOS
   development: halted


### PR DESCRIPTION
It even says on https://github.com/andrecarlucci/gta2net
> Automatically exported from code.google.com/p/gta2net

Also no activity on that fork either.