### PR TITLE
Remove dark reign 2

### DIFF
--- a/games/d.yaml
+++ b/games/d.yaml
@@ -100,17 +100,6 @@
   updated: 2015-04-06
   url: http://dark-oberon.sourceforge.net/
 
-- name: Dark Reign 2
-  lang:
-  - C++
-  license:
-  - As-is
-  development: halted
-  originals:
-  - Dark Reign 2
-  repo: https://github.com/grasmanek94/darkreign2
-  type: remake
-
 - name: DarkFO
   development: active
   lang:


### PR DESCRIPTION
Based on illegally leaked source code e.g. https://github.com/grasmanek94/darkreign2/blob/master/graphics/IMESHUtil.h