### PR TITLE
Fix/tag filter

### DIFF
--- a/_ext.py
+++ b/_ext.py
@@ -213,7 +213,7 @@ def show_validation_errors(data, validation_errors):
 
     show_errors(errors)
 
-    
+
 def validate_with_schema(source_data, schema_file):
     core = Core(source_data=source_data, schema_files=[schema_file])
     try:
@@ -223,7 +223,7 @@ def validate_with_schema(source_data, schema_file):
             show_validation_errors(source_data, core.errors)
         else:
             raise error
-    
+
 
 def parse_data(site):
     base = op.dirname(__file__)

--- a/render.py
+++ b/render.py
@@ -68,7 +68,7 @@ def render_all(target):
         name = slug(game[0][0])
         render_to('game.html', f'{target}/{name}/index.html', site=site, game=game)
 
-        
+
 def normalize(text):
     if not text:
         return ''

--- a/templates/games.html
+++ b/templates/games.html
@@ -142,7 +142,7 @@
 
 {% macro render(names, meta, items, mode) %}
   {% for name in names %}
-    {{ render_name(name, meta, loop.index, mode) }}
+    {{ render_name(name, meta, loop.index0, mode) }}
   {% endfor %}
 
   {% for game in items %}


### PR DESCRIPTION
The template's `render_name` macro only adds the `<dt>` id attribute when
the game idx is equal to zero (false). Using the Jinja2 loop with the
index starting at one, the id attribute with the name of the game wasn't added.

fix #1250, #1237