### PR TITLE
Fix docker build

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,4 +14,4 @@ jinja2 = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.7"
+python_version = "3"


### PR DESCRIPTION
pypa/pipenv#1050

Pipenv doesn't support multiple python versions and the base docker
image for nginx:1.17-alpine has python 3.8 and I want to enable
environments with python version greater than 3.7 to use pipenv.