### PR TITLE
Fix image and video gallery when sorted by updated date

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -45,13 +45,7 @@ function handleContentChanged() {
 
 // gallery handling
 (function() {
-  var els = document.getElementsByClassName('toggler');
-
-  for (var i = 0, l = els.length; i < l; i++) {
-    els[i].addEventListener('click', onclick);
-  }
-
-  function onclick(ev) {
+  var onclick = function(ev) {
     var t = ev.target;
     var gallery = t.parentNode.getElementsByClassName('gallery')[0];
     var raw = t.parentNode.getElementsByClassName('gallery-raw')[0];
@@ -62,7 +56,13 @@ function handleContentChanged() {
 
     if (raw && show_now) { gallery.insertAdjacentHTML('beforeend', raw.innerHTML); }
     else { gallery.innerHTML = ''; }
-  }
+  };
+
+  document.body.addEventListener('click', function(ev) {
+      if (!ev.target || !ev.target.matches("span.toggler")) return;
+
+      onclick(ev);
+  })
 })();
 
 // search handling


### PR DESCRIPTION
Changed to an event delegation strategy to handle the toggle of image
and video galleries.

When you clone a node in JavaScript, it doesn't copy attached events to
the new node.

Instead of attaching a new event for each game, It's attached to the
parent node to handle the click event when the css-class matches "toggle".

more about event delegate: https://davidwalsh.name/event-delegate

fix #1193