### PR TITLE
Fix Wikipedia link for Powerslave

### DIFF
--- a/originals/p.yaml
+++ b/originals/p.yaml
@@ -179,7 +179,7 @@
   names:
   - Exhumed
   external:
-    wikipedia: Powerslave
+    wikipedia: PowerSlave
   platform:
   - DOS
   - PlayStation


### PR DESCRIPTION
Wikipedia is case sensitive, the current link goes to an Iron Maiden album :metal: