### PR TITLE
Update & fix Minetest and Minecraft

### DIFF
--- a/games/m.yaml
+++ b/games/m.yaml
@@ -594,8 +594,8 @@
   - Minecraft
   status: playable
   repo: https://github.com/minetest/minetest
-  type: remake
-  updated: 2019-08-27
+  type: similar
+  updated: 2021-06-25
   url: https://www.minetest.net/
 
 - name: Minima

--- a/games/m.yaml
+++ b/games/m.yaml
@@ -398,10 +398,13 @@
   originals:
   - Minecraft
   status: playable
+  multiplayer:
+    - Online
+    - LAN
   repo: https://git.minetest.land/MineClone2/MineClone2
   type: clone
   info: A Minecraft Java Edition 1.12 clone built as a Minetest game
-  updated: 2021-06-18
+  updated: 2021-06-26
   url: https://content.minetest.net/packages/Wuzzy/mineclone2/
 
 - name: Minecraft
@@ -593,9 +596,13 @@
   originals:
   - Minecraft
   status: playable
+  multiplayer:
+    - Online
+    - LAN
   repo: https://github.com/minetest/minetest
+  info: Mintest is an engine, but ships with the game Minetest Game
   type: similar
-  updated: 2021-06-25
+  updated: 2021-06-26
   url: https://www.minetest.net/
 
 - name: Minima

--- a/originals/m.yaml
+++ b/originals/m.yaml
@@ -364,14 +364,6 @@
     - Arcade
 
 - name: Minecraft
-  names:
-  - 'Minecraft: Java Edition'
-  - 'Minecraft: Windows 10 Edition'
-  - 'Minecraft: Xbox 360 Edition'
-  - 'Minecraft: New Nintendo 3DS Edition'
-  - 'Minecraft: Wii U Edition'
-  - 'Minecraft: Playstation 3 Edition'
-  - 'Minecraft: Playstation Vita Edition'
   external:
     wikipedia: Minecraft
     website: https://www.minecraft.net  

--- a/originals/m.yaml
+++ b/originals/m.yaml
@@ -364,15 +364,40 @@
     - Arcade
 
 - name: Minecraft
+  names:
+  - 'Minecraft: Java Edition'
+  - 'Minecraft: Windows 10 Edition'
+  - 'Minecraft: Xbox 360 Edition'
+  - 'Minecraft: New Nintendo 3DS Edition'
+  - 'Minecraft: Wii U Edition'
+  - 'Minecraft: Playstation 3 Edition'
+  - 'Minecraft: Playstation Vita Edition'
   external:
     wikipedia: Minecraft
+    website: https://www.minecraft.net  
+  platform:
+  - Windows
+  - OSX
+  - Linux
+  - iOS
+  - Android
+  - Xbox 360
+  - Xbox One
+  - PlayStation 3
+  - PlayStation 4
+  - PlayStation Vita
+  - Nintendo Switch
+  - 3DS
+  - Windows
+  - Xbox 360
   meta:
     genre:
     - Action
-    - FPS
+    - RPG
     subgenre:
     - Survival
     - Sandbox
+    - Action RPG
     theme:
     - Fantasy
 


### PR DESCRIPTION
Minecraft isn't a First Person Shooter, though it has a bow and such. It has elements of an Action RPG.

Minetest is only similar, the core always focused more on the sandboxing part and does not have the RPG elements, minecraft has. They additionally developed apart over the last 10 years.
Minetest had mobs at first, but removed them later. It in general transformed into an engine with a default game (Minetest Game), but that one still lacks mobs, NPCs, XP, enchanting, dimensions and such. It basically only has mining, crafting, building and farming. And without additional mods it's also not possible to build machines like it's possible with Minecraft's redstone.

> The gameplay is mostly sandbox-style

https://content.minetest.net/packages/Minetest/minetest_game/