### PR TITLE
Add reone engine

### DIFF
--- a/games/r.yaml
+++ b/games/r.yaml
@@ -367,7 +367,7 @@
   url: http://cyxdown.free.fr/reminiscence/
   updated: 2021-04-16
 
-  - name: reone
+- name: reone
   framework:
   - SDL2
   - OpenGL
@@ -924,4 +924,3 @@
   type: remake
   updated: 2020-08-25
   url: https://ryzom.com/
-

--- a/games/r.yaml
+++ b/games/r.yaml
@@ -367,6 +367,26 @@
   url: http://cyxdown.free.fr/reminiscence/
   updated: 2021-04-16
 
+  - name: reone
+  framework:
+  - SDL2
+  - OpenGL
+  lang:
+  - C++
+  license:
+  - GPL3
+  content: commercial
+  development: active
+  originals:
+  - 'Star Wars: Knights of the Old Republic'
+  - "Star Wars: Knights of the Old Republic II \u2013 The Sith Lords"
+  status: semi-playable
+  type: remake
+  url: https://github.com/seedhartha/reone/
+  updated: 2021-06-30
+  video:
+    youtube: U80-mOOxmDM
+
 - name: replicant
   info: This version is no longer being developed, please follow https://github.com/madmoose/scummvm/tree/bladerunner/engines/bladerunner
     for new development.


### PR DESCRIPTION
reone is a free and open source game engine, capable of running Star Wars: Knights of the Old Republic and its sequel, The Sith Lords.
https://github.com/seedhartha/reone