### PR TITLE
add Ambermoon.net, a remake of Ambermoon

### DIFF
--- a/games/a.yaml
+++ b/games/a.yaml
@@ -225,7 +225,7 @@
   type: remake
   updated: 2014-01-12
   url: http://retrospec.sgn.net/users/ignacio/a8i.htm
-  
+
 - name: Alive_Reversing
   type: remake
   originals:
@@ -254,6 +254,30 @@
   repo: https://github.com/paulsapps/alive
   type: remake
   updated: 2016-03-08
+
+- name: Ambermoon.net
+  type: remake
+  originals:
+    - Ambermoon
+  repo: https://github.com/Pyrdacor/Ambermoon.net
+  development: very active
+  status: playable
+  lang:
+    - C#
+  framework:
+    - .NET
+  license:
+    - GPL3
+  content: commercial
+  updated: 2021-07-17
+  images:
+    - https://raw.githubusercontent.com/Pyrdacor/Ambermoon.net/master/Screenshots/MapRendering1.png
+    - https://raw.githubusercontent.com/Pyrdacor/Ambermoon.net/master/Screenshots/MapRendering2.png
+    - https://raw.githubusercontent.com/Pyrdacor/Ambermoon.net/master/Screenshots/Battle.png
+    - https://raw.githubusercontent.com/Pyrdacor/Ambermoon.net/master/Screenshots/Map3D.png
+    - https://raw.githubusercontent.com/Pyrdacor/Ambermoon.net/master/Screenshots/Monsters3D.png
+    - https://raw.githubusercontent.com/Pyrdacor/Ambermoon.net/master/Screenshots/EventBox.png
+    - https://raw.githubusercontent.com/Pyrdacor/Ambermoon.net/master/Screenshots/Merchant.png
 
 - name: Ancient Beast
   framework:

--- a/originals/a.yaml
+++ b/originals/a.yaml
@@ -175,6 +175,17 @@
     - Horror
     - Alternate Historical
 
+- name: Ambermoon
+  external:
+    wikipedia: Ambermoon
+  platform:
+  - Amiga
+  meta:
+    genre:
+    - RPG
+    theme:
+    - Fantasy
+
 - name: 'Anacreon: Reconstruction 4021'
   external:
     wikipedia: 'Anacreon: Reconstruction 4021'


### PR DESCRIPTION
Please note, while I used `content: free`, because the content is bundled in the release archive and free for the user, I believe the author actually uses the original assets from Ambermoon, i.e. most probably copyrighted content. I assume they are relying on its abandonware status and take the liberty to distribute it. I'm not sure if the `content` field should be changed to `commercial` or not.