### PR TITLE
OpenAWE: fix image URL

### DIFF
--- a/games/o.yaml
+++ b/games/o.yaml
@@ -573,7 +573,7 @@
   content: commercial
   updated: 2021-07-04
   images:
-  - https://github.com/OpenAWE-Project/OpenAWE/blob/master/screenshots/awan1.png
+  - https://raw.githubusercontent.com/OpenAWE-Project/OpenAWE/master/screenshots/awan1.png
 
 - name: OpenBiohazard2
   originals:


### PR DESCRIPTION
The previous image URL didn't lead to the actual image but to an HTML page, and
didn't show up on osgameclones.com.