### PR TITLE
Update OpenMC2 repo and status

### DIFF
--- a/games/o.yaml
+++ b/games/o.yaml
@@ -1337,7 +1337,7 @@
   updated: 2019-09-13
 
 - name: OpenMC2
-  development: sporadic
+  development: halted
   lang:
   - C++
   license:
@@ -1347,7 +1347,7 @@
   content: commercial
   originals:
   - Midnight Club II
-  repo: https://github.com/LRFLEW/OpenMC2
+  repo: https://github.com/OpenMC2/OpenMC2
   status: playable
   type: remake
   updated: 2018-04-08


### PR DESCRIPTION
I haven't made any "public" announcements to this, only mentioning it on the Midnight Champs Discord, so I'll explain here what's going on.

The first part is pretty simple: I moved the repository from my personal Github to a dedicated Github org. This is something I've meant to do for a while now, and is something I probably should have done from the start anyways. The org already existed, and it had the repository used to manage the project's dependencies, so it's a pretty obvious change to make.

The second change is that I'm officially changing the status of the project's development from sporadic to halted. I haven't worked on the project seriously in quite a while. I just haven't had the time to dedicate to the project, and my work on it is currently stuck in the middle of a transition between disassemblers (IDA Freeware to Ghidra). However, I am officially calling progress on the project halted due to the recent news involving Take-Two Interactive. The creators of a similar reverse engineering project, RE3, are being sued by Take-Two Interactive over the project and its use of reverse engineered code. I don't want to put more time and effort into this project for the time being if it would only result in it being taken down in the future. I have decided to officially halt the project for the time being, and I will consider my options for what to do with the project depending on how the case against the RE3 developers goes down.