### PR TITLE
Add FreeGemas

### DIFF
--- a/games/f.yaml
+++ b/games/f.yaml
@@ -608,6 +608,24 @@
   type: remake
   updated: 2016-01-12
 
+- name: FreeGemas
+  development: sporadic
+  status: playable
+  framework:
+  - SDL2
+  images:
+  - https://raw.githubusercontent.com/JoseTomasTocino/freegemas/static/images/screenshot_1.png
+  lang:
+  - C++
+  license:
+  - GPL2
+  content: open
+  originals:
+  - Bejeweled
+  repo: https://github.com/JoseTomasTocino/freegemas
+  type: clone
+  updated: 2021-10-06
+
 - name: freegish
   development: active
   framework:


### PR DESCRIPTION
FreeGemas is a simple, but quality Bejeweled clone. It works on Linux, MacOS and the Playstation Vita. The development is not super active, but recently some changes have been made. Full disclosure, I am a contributor and maintainer for this project.