### PR TITLE
Updated FreeRCT status

### DIFF
--- a/games/f.yaml
+++ b/games/f.yaml
@@ -758,14 +758,22 @@
 - name: FreeRCT
   lang:
   - C++
+  framework:
+  - SDL2
   license:
   - GPL2
-  development: halted
+  development: sporadic
   originals:
   - RollerCoaster Tycoon
   repo: http://github.com/FreeRCT/FreeRCT
   type: remake
-  updated: 2019-09-13
+  url: https://freerct.github.io/FreeRCT/
+  images:
+  - https://freerct.github.io/FreeRCT/images/screenshots/0_1/mainmenu.png
+  - https://freerct.github.io/FreeRCT/images/screenshots/0_1/mainview.png
+  - https://freerct.github.io/FreeRCT/images/screenshots/0_1/newpark.png
+  - https://freerct.github.io/FreeRCT/images/screenshots/0_1/persons.png
+  updated: 2021-10-11
 
 - name: Freeserf
   lang:


### PR DESCRIPTION
It looks like @FreeRCT is back with a new website and some commits to the repository. However I gave it sporadic development as it was in a long hiatus and isn't nearly as active as @OpenRCT2.