### PR TITLE
add official source repo for Little Big Adventure 1+2

### DIFF
--- a/games/l.yaml
+++ b/games/l.yaml
@@ -86,6 +86,38 @@
   type: remake
   updated: 2017-10-15
 
+- name: LBA1 Classic (Community)
+  originals:
+    - Little Big Adventure
+  type: remake
+  repo: https://github.com/2point21/lba1-classic-community
+  status: unplayable
+  lang:
+    - Assembly
+  license:
+    - GPL2
+  content: commercial
+  info: >-
+    Official source code of the original game's engine (not a remake). This is
+    the community-enhanced version of the repository.
+  updated: 2021-10-28
+
+- name: LBA2 Classic (Community)
+  originals:
+    - Little Big Adventure 2
+  type: remake
+  repo: https://github.com/2point21/lba2-classic-community
+  status: unplayable
+  lang:
+    - Assembly
+  license:
+    - GPL2
+  content: commercial
+  info: >-
+    Official source code of the original game's engine (not a remake). This is
+    the community-enhanced version of the repository.
+  updated: 2021-10-28
+
 - name: LBA2 Remake
   originals:
   - Little Big Adventure 2

--- a/originals/l.yaml
+++ b/originals/l.yaml
@@ -105,8 +105,13 @@
     - Action
 
 - name: Little Big Adventure
+  names:
+    - "Relentless: Twinsen's Adventure"
   external:
+    website: https://www.2point21.com/games/little-big-adventure-twinsen
     wikipedia: Little Big Adventure
+  platform:
+    - DOS
   meta:
     genre:
     - Action
@@ -118,6 +123,7 @@
   names:
   - Twinsen's Odyssey
   external:
+    website: https://www.2point21.com/games/little-big-adventure-2-twinsen-odyssey
     wikipedia: Little Big Adventure 2
   platform:
   - DOS


### PR DESCRIPTION
Marked as a remake per discussion at:
https://github.com/opengaming/osgameclones/discussions/1504

Source code release announcement:
https://blog.2point21.com/p/devlog-releasing-lba-open-source