### PR TITLE
Link to games on separate page

### DIFF
--- a/_ext.py
+++ b/_ext.py
@@ -27,9 +27,10 @@ class Game:
 
     @property
     def wikilink(self) -> str:
-        if self.meta['external']['wikipedia']:
+        try:
             return "http://en.wikipedia.org/wiki/" + self.meta['external']['wikipedia']
-        return self.meta['external']['website']
+        except KeyError:
+            return self.meta['external']['website']
 
 
 def abort(msg):

--- a/game.html
+++ b/game.html
@@ -4,8 +4,13 @@
 {{- common.head() }}
 {{ common.nav() }}
 
-<main class="single">
-  {{ games.render(game[0], game[1], game[2], 'game') }}
-</main>
+<div id="content">
+  <h2><a href="/">Back to list</a></h2>
+
+  <dl id="list">
+    {{ games.render(game, true) }}
+  </dl>
+  <dl id="sorted"></dl>
+</div>
 
 {{ common.footer() -}}

--- a/index.html
+++ b/index.html
@@ -43,8 +43,8 @@
 <div>
   <h2>New and updated games</h2>
   <dl>
-    {% for names, meta, game in site.new_games.values() %}
-      {{ games.render_game(names, meta, game) }}
+    {% for names, meta, clone in site.new_games.values() %}
+      {{ games.render_clone(names, meta, clone, true) }}
     {% endfor %}
   </dl>
 </div>
@@ -56,8 +56,8 @@
     <a class="add-link" href="/add_original.html" target="_blank"><i class="far fa-edit"></i>Add Original Game</a>
   </h2>
   <dl id="list">
-    {% for names, meta, items in site.games %}
-      {{ games.render(names, meta, items, 'games') }}
+    {% for game in site.games %}
+      {{ games.render(game, false) }}
     {% endfor %}
   </dl>
   <dl id="sorted"></dl>

--- a/render.py
+++ b/render.py
@@ -44,10 +44,6 @@ def ctx():
     return site
 
 
-def slug(s):
-    return re.sub(r'[^a-z0-9]+', '-', s.lower()).strip('-')
-
-
 def render_to(src, dst, **ctx):
     t = env().get_template(src)
 
@@ -73,8 +69,7 @@ def render_all(target):
     site = ctx()
     render_to('index.html', f'{target}/index.html', site=site)
     for game in ctx().games:
-        name = slug(game[0][0])
-        render_to('game.html', f'{target}/{name}/index.html', site=site, game=game)
+        render_to('game.html', f'{target}/{game.slug}/index.html', site=site, game=game)
 
 
 def normalize(text):

--- a/static/main.css
+++ b/static/main.css
@@ -133,7 +133,6 @@ dd + dt { margin-top: 1em; }
 .readers { float: right; font-size: small; }
 .icon { float: left; padding: 0.5em 0.3em 0 0; }
 .feed-icon a { float: right; padding-top: 0.5em; }
-.hash { color: grey; text-decoration: none; }
 .add-link { color: grey; text-decoration: none; font-weight: normal; font-size: 12px; }
 
 .tags-active dt, .tags-active dd {display: none}
@@ -321,4 +320,8 @@ dd + dt { margin-top: 1em; }
 
 #dl {
   display: none;
+}
+
+.game-spacer {
+  margin: 10px;
 }

--- a/templates/games.html
+++ b/templates/games.html
@@ -1,27 +1,26 @@
 {% import 'templates/video.html' as video %}
 {% import 'templates/tags.html' as tags %}
 
-{% macro render_name(name, meta, first, mode) %}
-  {%- if meta['external']['wikipedia'] -%}
-    {% set wikilink = "http://en.wikipedia.org/wiki/" + meta['external']['wikipedia'] %}
+{% macro render_name(name, game, first, use_external_link) %}
+  {%- if not use_external_link -%}
+    {% set link = "/" + game.slug %}
+  {%- elif game.meta['external']['wikipedia'] -%}
+    {% set link = "http://en.wikipedia.org/wiki/" + game.meta['external']['wikipedia'] %}
   {%- else -%}
-    {% set wikilink = meta['external']['website'] %}
+    {% set link = game.meta['external']['website'] %}
   {%- endif -%}
-
-  <dt {% if first %}id="{{ show_id(name, mode) }}"{% endif %} class="searchable">
-    <a href="{{ wikilink }}">{{ name }}</a>
-    {% if not idx %}<a href="#{{ show_id(name, mode) }}" class="hash">#</a>{% endif %}
-
+  <dt {% if first %}id="{{ show_id(name) }}"{% endif %} class="searchable">
+    <a href="{{ link }}">{{ name }}</a>
     {% if first %}
-      {{ tags.render_tag_groups('genre', meta['genre']) }}
-      {{ tags.render_tag_groups('subgenre', meta['subgenre']) }}
-      {{ tags.render_tag_groups('theme', meta['theme']) }}
+      {{ tags.render_tag_groups('genre', game.meta['genre']) }}
+      {{ tags.render_tag_groups('subgenre', game.meta['subgenre']) }}
+      {{ tags.render_tag_groups('theme', game.meta['theme']) }}
     {% endif %}
   </dt>
 {% endmacro %}
 
-{% macro show_id(name, mode) -%}
-  {{ name | lower | replace(' ', '-') }}-{{mode}}
+{% macro show_id(name) -%}
+  {{ name | lower | replace(' ', '-') }}
 {%- endmacro %}
 
 {% macro show_tags(game) -%}
@@ -62,8 +61,9 @@
   {{ show_keywords_names(meta.names_ascii) }}
 {%- endmacro %}
 
-{% macro render_game(names, meta, game) %}
+{% macro render_clone(names, meta, game, show_details) %}
   <div itemscope="" itemtype="http://schema.org/SoftwareSourceCode">
+    {%- set show_gallery = show_details and ('images' in game or 'video' in game) -%}
     <dd class="searchable {% if game.new %}new{% endif %}"
         data-name="{{ game.name }}"
         data-parent="
@@ -72,23 +72,20 @@
           {%- else -%}
             {% set name = names.0.0 %}
           {%- endif -%}
-          {{ show_id(name, mode) }}"
+          {{ show_id(name) }}"
         data-tags="{{ show_tags(game) }}"
         data-index="{{ show_keywords(game, names, meta) }}"
         data-updated="{{ game.updated }}"
     >
-      <span class="{% if 'images' in game or 'video' in game %}toggler{% else %}notoggler{% endif %}">&#x25b6;</span>
-
+      <span class="{% if show_gallery %}toggler{% else %}notoggler{% endif %}">&#x25b6;</span>
       {%- if 'url' in game -%}
         <a href="{{ game['url'] }}" itemprop="url"><span itemprop="name">{{ game['name'] }}</span></a>
       {%- else -%}
         <span itemprop="name">{{ game['name'] }}</span>
       {%- endif %}
-
       {%- if 'feed' in game %}
         <a href="{{ game['feed'] }}" class="feed-icon" title="Feed"><span class="fas fa-rss"></span></a>
       {%- endif %}
-
       {%- if 'repo' in game %}
         (
         <a itemprop="codeRepository" href="{{ game['repo'] }}">repo
@@ -99,53 +96,48 @@
         </a>
         )
       {%- endif %}
-
-      {{ tags.render_tag_groups('type', game['type'] | title) }}
+      {{ tags.render_tag_groups('type', game['type'] | title) if show_details }}
       {{ tags.render_tag_groups('status', game['status'] | title) }}
       {{ tags.render_tag_groups('development', game['development'] | title) }}
       {{ tags.render_tag_groups('lang', game['lang']) }}
-      {{ tags.render_tag_groups('framework', game['framework']) }}
-
-
-      {{ tags.render_tag_groups('content', game['content'] | title) }}
+      {{ tags.render_tag_groups('framework', game['framework']) if show_details }}
+      {{ tags.render_tag_groups('content', game['content'] | title) if show_details }}
       {{ tags.render_tag_groups('license', game['license']) }}
+      {{ tags.render_tag_groups('multiplayer', game['multiplayer']) if 'multiplayer' in game and show_details }}
+      {%- if 'info' in game and show_details %}
+        <div itemprop="description">{{ game['info'] }}</div>
+      {% endif %}
+      {% if show_gallery %}
+        <div class="gallery" style="display: none"></div>
+        {% if game['images'] | length > 0 -%}
+          <script class="gallery-json" data-game="{{ game['name'] }}" type="text/json">
+            {{- game['images'] | join(', ') -}}
+          </script>
+        {% endif %}
+        <script class="gallery-raw" type="text/plain">
+          {% for imageUrl in game.get('images', []) %}
+            <img src="{{ imageUrl }}" itemprop="image" alt="{{ game['name'] }}">
+          {% endfor %}
 
-      {%- if 'multiplayer' in game %}
-        {{ tags.render_tag_groups('multiplayer', game['multiplayer']) }}
-      {%- endif %}
-
-      {%- if 'info' in game %}<div itemprop="description">{{ game['info'] }}</div>{% endif %}
-
-      <div class="gallery" style="display: none"></div>
-
-      {% if game['images'] | length > 0 -%}
-        <script class="gallery-json" data-game="{{ game['name'] }}" type="text/json">
-          {{- game['images'] | join(', ') -}}
+          {% if 'video' in game %}
+            {% if 'youtube' in game['video'] %}{{ video.render_youtube(game['video']['youtube']) }}{% endif %}
+            {% if 'vimeo' in game['video'] %}{{ video.render_vimeo(game['video']['vimeo']) }}{% endif %}
+            {% if 'moddb' in game['video'] %}{{ video.render_moddb(game['video']['moddb']) }}{% endif %}
+            {% if 'indiedb' in game['video'] %}{{ video.render_indiedb(game['video']['indiedb']) }}{% endif %}
+          {%- endif %}
         </script>
       {% endif %}
-
-      <script class="gallery-raw" type="text/plain">
-        {% for imageUrl in game.get('images', []) %}
-          <img src="{{ imageUrl }}" itemprop="image" alt="{{ game['name'] }}">
-        {% endfor %}
-
-        {% if 'video' in game %}
-          {% if 'youtube' in game['video'] %}{{ video.render_youtube(game['video']['youtube']) }}{% endif %}
-          {% if 'vimeo' in game['video'] %}{{ video.render_vimeo(game['video']['vimeo']) }}{% endif %}
-          {% if 'moddb' in game['video'] %}{{ video.render_moddb(game['video']['moddb']) }}{% endif %}
-          {% if 'indiedb' in game['video'] %}{{ video.render_indiedb(game['video']['indiedb']) }}{% endif %}
-        {%- endif %}
-      </script>
     </dd>
   </div>
 {% endmacro %}
 
-{% macro render(names, meta, items, mode) %}
-  {% for name in names %}
-    {{ render_name(name, meta, loop.index0 == 0, mode) }}
+{% macro render(game, show_details) %}
+  <div class="game-spacer"></div>
+  {% for name in game.names %}
+    {{ render_name(name, game, loop.index0 == 0, show_details) }}
   {% endfor %}
 
-  {% for game in items %}
-    {{ render_game(names, meta, game) }}
+  {% for clone in game.clones %}
+    {{ render_clone(game.names, game.meta, clone, show_details) }}
   {% endfor %}
 {% endmacro %}

--- a/templates/games.html
+++ b/templates/games.html
@@ -4,10 +4,8 @@
 {% macro render_name(name, game, first, use_external_link) %}
   {%- if not use_external_link -%}
     {% set link = "/" + game.slug %}
-  {%- elif game.meta['external']['wikipedia'] -%}
-    {% set link = "http://en.wikipedia.org/wiki/" + game.meta['external']['wikipedia'] %}
   {%- else -%}
-    {% set link = game.meta['external']['website'] %}
+    {% set link = game.wikilink %}
   {%- endif -%}
   <dt {% if first %}id="{{ show_id(name) }}"{% endif %} class="searchable">
     <a href="{{ link }}">{{ name }}</a>


### PR DESCRIPTION
Game (original) names link to a separate page showing clones for that game only.

![os](https://user-images.githubusercontent.com/1083215/140302243-bc6b9788-c1f6-4ad7-93fc-718308e9b1c8.gif)

Make the main (list) page more concise:
- Remove bookmarks
- Remove image/videos
- Remove "type"
- Remove "multiplayer"
- Remove "framework"
- Remove "content"
- Remove "info"

On the game detail page, show everything, and the original game links to wikipedia/external URL as before.

Also: add a spacer between different games.

The goal of this changeset is to improve readability #1430  while also showing as much detail as possible, in the game detail page. Therefore on the list page show only the most important info: status, development, license, language.

This gives us the freedom to add even more detail, in the game detail page, without harming readability. 
