### PR TITLE
Add Signus: The Artefact Wars

### DIFF
--- a/games/s.yaml
+++ b/games/s.yaml
@@ -434,6 +434,25 @@
   updated: 2015-04-08
   url: http://soaos.sourceforge.net/
 
+- name: 'Signus: The Artefact Wars'
+  type: remake
+  originals:
+  - 'Signus: The Artefact Wars'
+  repo: 'https://github.com/signus-game/signus'
+  development: complete
+  status: playable
+  lang:
+  - C++
+  framework:
+  - SDL2
+  license:
+  - GPL2
+  content: open
+  info: Complete source port of the original game
+  updated: 2021-11-12
+  video:
+    youtube: SHhLHVwoLFA
+
 - name: Silent Hill 2 Enhancement
   originals:
   - Silent Hill 2

--- a/originals/s.yaml
+++ b/originals/s.yaml
@@ -335,6 +335,17 @@
     - Action
     - RPG
 
+- name: 'Signus: The Artefact Wars'
+  external:
+    website: 'http://signus.paan.cz/'
+  platform:
+  - Windows
+  meta:
+    genre:
+    - Turn-Based Strategy
+    theme:
+    - Sci-Fi
+
 - name: Silencer
   external:
     wikipedia: Silencer (video game)


### PR DESCRIPTION
Signus: The Artefact Wars is a Czech turn-based strategy wargame originally released in 1998. The original developers have open-sourced the game on SourceForge back in 2002 and I've finished porting it to Linux and modern Windows earlier this year.

The game has no official website and the only Wikipedia page about it is in Czech so the "official" URL points to a fan website with some English content.