### PR TITLE
Updates of some repo URLs that changed, some licenses and slight corrections of original spellings

### DIFF
--- a/games/0.yaml
+++ b/games/0.yaml
@@ -67,7 +67,7 @@
   updated: 2019-04-15
   url: https://kilgoretroutmaskreplicant.gitlab.io/plain-html/
 
-- name: 2006-rebotted
+- name: 2006scape
   originals:
   - Runescape Classic
   type: remake

--- a/games/0.yaml
+++ b/games/0.yaml
@@ -71,8 +71,8 @@
   originals:
   - Runescape Classic
   type: remake
-  repo: https://github.com/2006rebotted/2006rebotted
-  url: https://rsrebotted.com/
+  repo: https://github.com/2006-Scape/2006Scape
+  url: https://2006scape.org/
   development: active
   status: playable
   multiplayer:
@@ -118,7 +118,7 @@
   - GPL3
   development: halted
   originals:
-  - Simcity
+  - SimCity
   repo: https://github.com/lo-th/3d.city
   type: clone
   updated: 2019-04-15

--- a/games/0.yaml
+++ b/games/0.yaml
@@ -85,7 +85,7 @@
   license:
     - BSD2
   info: Open source 2006 Runescape emulation with botting
-  updated: 2020-08-31
+  updated: 2021-11-20
   images:
     - 'https://i.imgur.com/X9SS8ep.png'
     - 'https://i.imgur.com/HxIctfS.png'

--- a/games/a.yaml
+++ b/games/a.yaml
@@ -361,7 +361,7 @@
   - MIT
   development: active
   originals:
-  - AquaStax
+  - Aquastax
   repo: https://github.com/LongSteve/aquastax
   type: remake
   updated: 2017-12-12

--- a/games/b.yaml
+++ b/games/b.yaml
@@ -164,7 +164,7 @@
   - GPL3
   development: halted
   originals:
-  - Battlecity
+  - Battle City
   repo: https://github.com/Deceth/Battle-City
   status: playable
   type: remake

--- a/games/c.yaml
+++ b/games/c.yaml
@@ -106,7 +106,7 @@
   - MAME
   content: commercial
   originals:
-  - Outrun
+  - Out Run
   repo: https://github.com/djyt/cannonball
   status: playable
   type: remake
@@ -493,7 +493,7 @@
 
 - name: Citybound
   originals:
-  - Simcity
+  - SimCity
   type: clone
   repo: https://github.com/citybound/citybound
   url: https://aeplay.org/citybound
@@ -545,7 +545,7 @@
   - C
   originals:
   - Call to Power II
-  repo: https://github.com/civctp2/civctp2/
+  repo: https://github.com/civctp2/civctp2
   type: remake
   updated: 2020-08-25
   url: https://ctp2.darkdust.net/
@@ -780,7 +780,7 @@
   - Crusade in Europe
   - Decision in the Desert
   - Conflict in Vietnam
-  repo: https://github.com/pwiecz/command_series/
+  repo: https://github.com/pwiecz/command_series
   development: active
   status: playable
   lang:
@@ -1213,7 +1213,7 @@
 
 - name: Cytopia
   originals:
-  - Simcity
+  - SimCity
   type: clone
   repo: https://github.com/CytopiaTeam/Cytopia
   url: https://cytopia.net/

--- a/games/d.yaml
+++ b/games/d.yaml
@@ -134,7 +134,7 @@
   - Quake
   repo: https://gitlab.com/xonotic/darkplaces
   type: remake
-  updated: 2015-07-02
+  updated: 2021-11-20
   url: https://icculus.org/twilight/darkplaces/
 
 - name: datastorm

--- a/games/d.yaml
+++ b/games/d.yaml
@@ -132,7 +132,7 @@
   development: active
   originals:
   - Quake
-  repo: https://svn.icculus.org/twilight/trunk/darkplaces/
+  repo: https://gitlab.com/xonotic/darkplaces.git
   type: remake
   updated: 2015-07-02
   url: https://icculus.org/twilight/darkplaces/
@@ -517,7 +517,7 @@
 
 - name: Divercity
   originals:
-  - Simcity
+  - SimCity
   type: clone
   repo: 'https://github.com/Team--Rocket/divercity'
   url: 'https://team--rocket.github.io/divercity/'

--- a/games/d.yaml
+++ b/games/d.yaml
@@ -132,7 +132,7 @@
   development: active
   originals:
   - Quake
-  repo: https://gitlab.com/xonotic/darkplaces.git
+  repo: https://gitlab.com/xonotic/darkplaces
   type: remake
   updated: 2015-07-02
   url: https://icculus.org/twilight/darkplaces/

--- a/games/g.yaml
+++ b/games/g.yaml
@@ -135,8 +135,8 @@
   - Flag Catcher
   repo: https://github.com/ceva24/gift-grabber
   type: remake
-  updated: 2015-08-31
-  url: https://ceva24.github.io/
+  updated: 2021-11-20
+  url: https://ceva24.github.io/gift-grabber/
 
 - name: Gigalomania
   images:
@@ -423,7 +423,7 @@
   - Qt
   license:
   - GPL2
-  updated: 2020-08-25
+  updated: 2021-11-20
   images:
   - https://apps.kde.org/thumbnails/org.kde.granatier/granatier.png
 

--- a/games/g.yaml
+++ b/games/g.yaml
@@ -133,7 +133,7 @@
   development: active
   originals:
   - Flag Catcher
-  repo: https://github.com/Ceva24/ceva24.github.io
+  repo: https://github.com/ceva24/gift-grabber
   type: remake
   updated: 2015-08-31
   url: https://ceva24.github.io/
@@ -148,7 +148,7 @@
   - GPL2
   development: sporadic
   originals:
-  - Mega Lo Mania
+  - Mega-Lo-Mania
   repo: https://sourceforge.net/projects/gigalomania/
   status: playable
   type: remake
@@ -411,7 +411,7 @@
   - Bomberman
   type: clone
   repo: https://invent.kde.org/games/granatier
-  url: https://kde.org/applications/games/org.kde.granatier
+  url: https://apps.kde.org/granatier/
   development: very active
   status: playable
   multiplayer:
@@ -425,7 +425,7 @@
   - GPL2
   updated: 2020-08-25
   images:
-  - https://kde.org/applications/thumbnails/org.kde.granatier/granatier.png
+  - https://apps.kde.org/thumbnails/org.kde.granatier/granatier.png
 
 - name: grid-leader
   framework:

--- a/games/h.yaml
+++ b/games/h.yaml
@@ -89,7 +89,7 @@
   repo: https://github.com/Greentwip/HoneyTown
   status: semi-playable
   type: remake
-  updated: 2019-11-08
+  updated: 2021-11-20
   url: http://twitter.com/GreentwipHealth
 
 

--- a/games/h.yaml
+++ b/games/h.yaml
@@ -77,7 +77,7 @@
   video:
     youtube: iA4lOiYS2s8
   
-- name: Greentwip's Harvest Moon
+- name: Honey Town
   info: Harvest Moon (SNES) remake for UWP and Xbox One.
   lang:
   - C#

--- a/games/h.yaml
+++ b/games/h.yaml
@@ -86,7 +86,7 @@
   development: active
   originals:
   - Story of Seasons series
-  repo: https://github.com/greentwip/HarvestMoon
+  repo: https://github.com/Greentwip/HoneyTown
   status: semi-playable
   type: remake
   updated: 2019-11-08

--- a/games/k.yaml
+++ b/games/k.yaml
@@ -64,7 +64,7 @@
   - Atomix
   repo: https://invent.kde.org/games/katomic
   type: remake
-  updated: 2020-08-25
+  updated: 2021-11-20
   url: https://apps.kde.org/katomic/
 
 - name: Keen Dreams
@@ -148,7 +148,7 @@
   repo: https://invent.kde.org/games/kgoldrunner
   status: playable
   type: remake
-  updated: 2020-08-25
+  updated: 2021-11-20
   url: https://apps.kde.org/kgoldrunner/
 
 - name: KidChameleonRemake

--- a/games/k.yaml
+++ b/games/k.yaml
@@ -54,7 +54,7 @@
 
 - name: KAtomic
   images:
-  - https://www.kde.org/images/screenshots/katomic.png
+  - https://cdn.kde.org/screenshots/katomic/katomic.png
   lang:
   - C++
   license:
@@ -65,7 +65,7 @@
   repo: https://invent.kde.org/games/katomic
   type: remake
   updated: 2020-08-25
-  url: https://www.kde.org/applications/games/katomic/
+  url: https://apps.kde.org/katomic/
 
 - name: Keen Dreams
   images:
@@ -137,7 +137,7 @@
   framework:
   - SDL2
   images:
-  - https://www.kde.org/images/screenshots/kgoldrunner.png
+  - https://cdn.kde.org/screenshots/kgoldrunner/kgoldrunner.png
   lang:
   - C++
   license:
@@ -149,7 +149,7 @@
   status: playable
   type: remake
   updated: 2020-08-25
-  url: https://www.kde.org/applications/games/kgoldrunner/
+  url: https://apps.kde.org/kgoldrunner/
 
 - name: KidChameleonRemake
   lang:

--- a/games/l.yaml
+++ b/games/l.yaml
@@ -82,7 +82,7 @@
   development: active
   originals:
   - Terraria
-  repo: https://github.com/LastTryR/LastTry
+  repo: https://github.com/egordorichev/LastTry
   type: remake
   updated: 2017-10-15
 
@@ -127,7 +127,7 @@
   status: semi-playable
   content: commercial
   lang:
-  - JavaScript
+  - TypeScript
   framework:
   - three.js
   - React
@@ -153,7 +153,7 @@
   lang:
   - C++
   license:
-  - GPL2
+  - GPL3
   info: >-
     LBreakoutHD is a scaleable 16:9 remake of LBreakout2. You try to clear levels
     full of different types of bricks and extras by using your paddle to aim balls
@@ -479,7 +479,7 @@
   development: halted
   status: playable
   originals:
-  - Simcity
+  - SimCity
   repo: https://sourceforge.net/projects/lincity/
   type: clone
   url: http://lincity.sourceforge.net/
@@ -498,7 +498,7 @@
   development: halted
   status: playable
   originals:
-  - Simcity
+  - SimCity
   repo: https://github.com/lincity-ng/lincity-ng
   type: clone
   url: https://www.berlios.de/software/lincity-ng/
@@ -537,7 +537,7 @@
   development: active
   originals:
   - Lionheart
-  repo: https://github.com/DjThunder/lionheart-remake
+  repo: https://github.com/b3dgs/lionheart-remake
   type: remake
   updated: 2019-11-20
   url: http://www.b3dgs.com/

--- a/games/l.yaml
+++ b/games/l.yaml
@@ -79,7 +79,7 @@
   - Java
   license:
   - MIT
-  development: active
+  development: halted
   originals:
   - Terraria
   repo: https://github.com/egordorichev/LastTry

--- a/games/l.yaml
+++ b/games/l.yaml
@@ -84,7 +84,7 @@
   - Terraria
   repo: https://github.com/egordorichev/LastTry
   type: remake
-  updated: 2017-10-15
+  updated: 2021-11-20
 
 - name: LBA1 Classic (Community)
   originals:
@@ -539,7 +539,7 @@
   - Lionheart
   repo: https://github.com/b3dgs/lionheart-remake
   type: remake
-  updated: 2019-11-20
+  updated: 2021-11-20
   url: http://www.b3dgs.com/
 
 - name: Lix

--- a/games/m.yaml
+++ b/games/m.yaml
@@ -365,7 +365,7 @@
   - GPL3
   development: halted
   originals:
-  - Simcity
+  - SimCity
   status: playable
   repo: https://github.com/SimHacker/micropolis
   type: remake
@@ -381,7 +381,7 @@
   - GPL3
   development: sporadic
   originals:
-  - Simcity
+  - SimCity
   repo: https://github.com/graememcc/micropolisJS
   type: remake
   updated: 2019-08-27

--- a/games/o.yaml
+++ b/games/o.yaml
@@ -200,7 +200,7 @@
   originals:
   - Pac-Man
   type: remake
-  repo: 'https://github.com/atroel/open-greedy/'
+  repo: https://github.com/atroel/open-greedy
   url: 'http://troel.net/opengreedy/'
   development: halted
   status: playable
@@ -750,7 +750,7 @@
   - GPL2
   development: halted
   originals:
-  - Simcity
+  - SimCity
   repo: svn://svn.code.sf.net/p/opencity/code/trunk
   type: clone
   updated: 2015-04-03
@@ -1778,8 +1778,8 @@
   - WebGL
   license:
   - GPL3
-  url: https://github.com/rage8885/OpenSC2K
-  repo: https://github.com/rage8885/OpenSC2K
+  url: https://github.com/nicholas-ochoa/OpenSC2K
+  repo: https://github.com/nicholas-ochoa/OpenSC2K
   updated: 2019-01-30
   images:
   - https://raw.githubusercontent.com/rage8885/OpenSC2K/master/screenshots/1.png
@@ -2319,7 +2319,7 @@
   - As-is
   development: halted
   originals:
-  - Outrun
+  - Out Run
   repo: https://www.dropbox.com/s/d803ueu0l4cgk6k/outrunBETA.zip
   type: remake
   updated: 2015-04-16

--- a/games/o.yaml
+++ b/games/o.yaml
@@ -1778,7 +1778,6 @@
   - WebGL
   license:
   - GPL3
-  url: https://github.com/nicholas-ochoa/OpenSC2K
   repo: https://github.com/nicholas-ochoa/OpenSC2K
   updated: 2019-01-30
   images:

--- a/games/o.yaml
+++ b/games/o.yaml
@@ -1779,7 +1779,7 @@
   license:
   - GPL3
   repo: https://github.com/nicholas-ochoa/OpenSC2K
-  updated: 2019-01-30
+  updated: 2021-11-20
   images:
   - https://raw.githubusercontent.com/rage8885/OpenSC2K/master/screenshots/1.png
   - https://raw.githubusercontent.com/rage8885/OpenSC2K/master/screenshots/2.png

--- a/games/r.yaml
+++ b/games/r.yaml
@@ -410,7 +410,7 @@
   development: halted
   originals:
   - Rescue!
-  repo: http://sf.net/p/rescue/code/
+  repo: https://sourceforge.net/projects/rescue/
   type: remake
   updated: 2015-04-25
   url: http://rescue.sourceforge.net/

--- a/games/r.yaml
+++ b/games/r.yaml
@@ -412,7 +412,7 @@
   - Rescue!
   repo: https://sourceforge.net/projects/rescue/
   type: remake
-  updated: 2015-04-25
+  updated: 2021-11-20
   url: http://rescue.sourceforge.net/
 
 - name: ResidualVM

--- a/games/r.yaml
+++ b/games/r.yaml
@@ -406,7 +406,7 @@
   lang:
   - Java
   license:
-  - GPL2
+  - GPL3
   development: halted
   originals:
   - Rescue!

--- a/games/s.yaml
+++ b/games/s.yaml
@@ -88,7 +88,7 @@
   development: halted
   originals:
   - Starcraft
-  repo: https://github.com/toshok/scsharp/
+  repo: https://github.com/toshok/scsharp
   status: unplayable
   type: remake
   updated: 2021-01-07

--- a/games/v.yaml
+++ b/games/v.yaml
@@ -57,7 +57,7 @@
   - 'Command & Conquer'
   - 'Command & Conquer: Red Alert'
   info: VanillaConquer is based on the open sourced code for the Command & Conquer Remaster and can play the original games content standalone.
-  repo: https://github.com/Vanilla-Conquer/Vanilla-Conquer
+  repo: https://github.com/TheAssemblyArmada/Vanilla-Conquer
   type: remake
   status: playable
   updated: 2020-07-22

--- a/games/v.yaml
+++ b/games/v.yaml
@@ -60,7 +60,7 @@
   repo: https://github.com/TheAssemblyArmada/Vanilla-Conquer
   type: remake
   status: playable
-  updated: 2020-07-22
+  updated: 2021-11-20
 
 - name: VASSAL
   images:

--- a/games/w.yaml
+++ b/games/w.yaml
@@ -217,7 +217,7 @@
   - https://media.githubusercontent.com/media/cyco/WebFun/master/docs/screenshots/game-start.png
   - https://media.githubusercontent.com/media/cyco/WebFun/master/docs/screenshots/game-fight.png
   lang:
-  - JavaScript
+  - TypeScript
   license:
   - MIT
   content: commercial
@@ -269,7 +269,7 @@
   - LAN
   originals:
   - The Settlers II
-  repo: https://launchpad.net/widelands
+  repo: https://github.com/widelands/widelands
   type: clone
   url: http://wl.widelands.org/
   updated: 2019-12-23

--- a/games/w.yaml
+++ b/games/w.yaml
@@ -272,7 +272,7 @@
   repo: https://github.com/widelands/widelands
   type: clone
   url: http://wl.widelands.org/
-  updated: 2019-12-23
+  updated: 2021-11-20
 
 - name: Willow-Game-Remake
   lang:

--- a/games/y.yaml
+++ b/games/y.yaml
@@ -6,7 +6,7 @@
   development: active
   originals:
   - Quake 2
-  repo: https://github.com/yquake2
+  repo: https://github.com/yquake2/yquake2
   type: remake
   updated: 2015-04-05
   url: http://www.yamagi.org/quake2/

--- a/games/z.yaml
+++ b/games/z.yaml
@@ -156,7 +156,7 @@
   url: https://zero-k.info/
   video:
     youtube: dyhzqcf7NJM
-  updated: 2019-10-21
+  updated: 2021-11-20
 
 - name: Zeta
   type: tool

--- a/games/z.yaml
+++ b/games/z.yaml
@@ -152,7 +152,7 @@
   - Total Annihilation
   - Supreme Commander
   status: playable
-  repo: https://github.com/ZeroK-RTS
+  repo: https://github.com/ZeroK-RTS/Zero-K
   url: https://zero-k.info/
   video:
     youtube: dyhzqcf7NJM

--- a/originals/a.yaml
+++ b/originals/a.yaml
@@ -232,7 +232,7 @@
     - Adventure
     - Platform
 
-- name: AquaStax
+- name: Aquastax
   external:
     wikipedia: Aquastax
   meta:

--- a/originals/m.yaml
+++ b/originals/m.yaml
@@ -246,9 +246,9 @@
     genre:
     - FPS
 
-- name: Mega Lo Mania
+- name: Mega-Lo-Mania
   external:
-    wikipedia: Mega Lo Mania
+    wikipedia: Mega-Lo-Mania
   meta:
     genre:
     - Real-Time Strategy

--- a/originals/o.yaml
+++ b/originals/o.yaml
@@ -92,9 +92,9 @@
   external:
     wikipedia: Outpost (1994 video game)
 
-- name: Outrun
+- name: Out Run
   external:
-    wikipedia: Outrun
+    wikipedia: Out Run
   meta:
     genre:
     - Arcade

--- a/originals/s.yaml
+++ b/originals/s.yaml
@@ -383,9 +383,9 @@
     theme:
     - World War II
 
-- name: Simcity
+- name: SimCity
   external:
-    wikipedia: Simcity
+    wikipedia: SimCity
   meta:
     genre:
     - Simulation


### PR DESCRIPTION
Corrected some original spellings (see their Wikipedia pages for verification): AquaStax -> Aquastax, Mega Lo Mania -> Mega-Lo-Mania, Outrun -> Out Run and Simcity to SimCity. Also corrected within each game entry where these originals were referenced.

Corrected some licenses, are GPL3 but were marked GPL2 (may have been upgraded in between): see http://svn.code.sf.net/p/lgames/code/trunk/lbreakouthd/COPYING and http://svn.code.sf.net/p/rescue/code/Rescue/gpl.txt

And updated some URLs (repos mostly) that have changed. Simply follow the old URLs to see that they were outdated.

I haven't changed the 'updated' field. Would do that after the PR has been reviewed.