### PR TITLE
Mark Grit Engine as dead

### DIFF
--- a/games/g.yaml
+++ b/games/g.yaml
@@ -482,14 +482,14 @@
   originals:
   - 'Grand Theft Auto: San Andreas'
   repo: https://github.com/grit-engine/grit-engine
-  development: sporadic
+  development: halted
   lang:
   - C++
   license:
   - MIT
   content: commercial
   info: Contains asset extraction tools for GTA:SA https://github.com/grit-engine/grit-engine/tree/master/gtasa
-  updated: 2020-08-31
+  updated: 2021-12-19
   video:
     youtube: gARVzn3nBsQ
 


### PR DESCRIPTION
@grit-engine hasn't seen an update. The homepage is down. See also https://sourceforge.net/projects/gritengine/