### PR TITLE
Adding 2 projects for the game Lego Universe

### DIFF
--- a/games/d.yaml
+++ b/games/d.yaml
@@ -1197,3 +1197,28 @@
   updated: 2019-11-14
   images:
   - https://raw.githubusercontent.com/akien-mga/dynadungeons/master/background.png
+  
+- name: Darkflame Universe
+  originals:
+  - Lego Universe
+  type: remake
+  repo: 'https://github.com/DarkflameServer/DarkflameUniverse'
+  url: 'https://darkflameuniverse.org/'
+  development: active
+  status: playable
+  multiplayer:
+  - Local
+  - Online
+  - LAN
+  content: commercial
+  lang:
+  - C++
+  license:
+  - AGPL3
+  info: This project is a server emulating an MMO developed by NetDevil and released in 2010.
+  updated: '2022-02-15'
+  images:
+  - 'https://pbs.twimg.com/media/E5jL9BvWQAQOeYQ?format=jpg&name=900x900'
+  - 'https://pbs.twimg.com/media/E17cXShWYAMLJI9?format=jpg&name=large'
+  video:
+  youtube: ZhzMy-o0ByM

--- a/games/d.yaml
+++ b/games/d.yaml
@@ -1221,4 +1221,4 @@
   - 'https://pbs.twimg.com/media/E5jL9BvWQAQOeYQ?format=jpg&name=900x900'
   - 'https://pbs.twimg.com/media/E17cXShWYAMLJI9?format=jpg&name=large'
   video:
-  youtube: ZhzMy-o0ByM
+    youtube: ZhzMy-o0ByM

--- a/games/d.yaml
+++ b/games/d.yaml
@@ -1202,7 +1202,7 @@
   originals:
   - Lego Universe
   type: remake
-  repo: 'https://github.com/DarkflameServer/DarkflameUniverse'
+  repo: https://github.com/DarkflameUniverse/DarkflameServer
   url: 'https://darkflameuniverse.org/'
   development: active
   status: playable

--- a/games/u.yaml
+++ b/games/u.yaml
@@ -479,3 +479,22 @@
   images:
   - >-
     https://user-images.githubusercontent.com/5136903/125014285-afc65580-e06d-11eb-80c0-0a1992a7d0ff.jpg
+
+- name: UchuServer
+  originals:
+  - Lego Universe
+  type: remake
+  repo: 'https://github.com/UchuServer/Uchu'
+  development: active
+  status: playable
+  multiplayer:
+  - Local
+  - Online
+  - LAN
+  content: commercial
+  lang:
+  - 'C#'
+  license:
+  - GPL3
+  info: A Server project emulating original data from NetDevil's Lego Universe (2010)
+  updated: '2022-02-15'

--- a/games/u.yaml
+++ b/games/u.yaml
@@ -498,3 +498,5 @@
   - GPL3
   info: A Server project emulating original data from NetDevil's Lego Universe (2010)
   updated: '2022-02-15'
+  video:
+    youtube: _b6HYmdcA8c

--- a/originals/l.yaml
+++ b/originals/l.yaml
@@ -96,6 +96,16 @@
     genre:
     - Real-Time Strategy
 
+- name: Lego Universe
+  external:
+    wikipedia: Lego Universe
+  platform:
+  - OSX
+  - Windows
+  meta:
+    genre:
+    - MMORPG
+
 - name: Lemmings
   external:
     wikipedia: Lemmings (video game)


### PR DESCRIPTION
This pull request adds the 2 largest open-source projects emulating [Lego Universe](https://en.wikipedia.org/wiki/Lego_Universe), a NetDevil MMORPG released in 2010.

These 2 projects have decently-sized communities and both are almost 100% functionally equivalent to the original game.