### PR TITLE
Update info about TES3MP

### DIFF
--- a/games/t.yaml
+++ b/games/t.yaml
@@ -164,7 +164,13 @@
   info: TES3MP is a project adding multiplayer functionality to OpenMW
   updated: '2022-02-07'
   images:
-  - 'https://i2.wp.com/openmw.org/wp-content/uploads/2017/07/hA3oZhX.png'
+  - https://media.moddb.com/cache/images/engines/1/1/929/thumb_620x2000/170828b.png
+  - https://media.moddb.com/cache/images/engines/1/1/929/thumb_620x2000/vlcsnap-2983-11-27-07h06m58s509.png
+  - https://media.moddb.com/cache/images/engines/1/1/929/thumb_620x2000/vlcsnap-4274-01-22-03h12m11s414.png
+  - https://media.moddb.com/cache/images/engines/1/1/929/thumb_620x2000/vlcsnap-2432-09-08-08h21m43s889.png
+  - https://media.moddb.com/cache/images/engines/1/1/929/thumb_620x2000/vlcsnap-7947-01-28-20h26m56s612.png
+  video:
+    moddb: 1907883
   video:
     youtube: aZZ0piRvI58
 

--- a/games/t.yaml
+++ b/games/t.yaml
@@ -171,6 +171,7 @@
   - https://media.moddb.com/cache/images/engines/1/1/929/thumb_620x2000/vlcsnap-7947-01-28-20h26m56s612.png
   video:
     youtube: aZZ0piRvI58
+    moddb: 1907883
 
 - name: tetris
   images:

--- a/games/t.yaml
+++ b/games/t.yaml
@@ -170,8 +170,6 @@
   - https://media.moddb.com/cache/images/engines/1/1/929/thumb_620x2000/vlcsnap-2432-09-08-08h21m43s889.png
   - https://media.moddb.com/cache/images/engines/1/1/929/thumb_620x2000/vlcsnap-7947-01-28-20h26m56s612.png
   video:
-    moddb: 1907883
-  video:
     youtube: aZZ0piRvI58
 
 - name: tetris

--- a/games/t.yaml
+++ b/games/t.yaml
@@ -145,26 +145,28 @@
   type: remake
   updated: 2015-06-18
 
-- name: TES3MP
-  images:
-  - https://i2.wp.com/openmw.org/wp-content/uploads/2017/07/hA3oZhX.png
+  name: TES3MP
+  originals:
+  - 'The Elder Scrolls III: Morrowind'
+  type: remake
+  repo: 'https://github.com/TES3MP/openmw-tes3mp'
+  url: 'http://tes3mp.com/'
+  development: active
+  status: playable
+  multiplayer:
+  - Online
+  - LAN
+  content: swappable
   lang:
   - C++
   license:
   - GPL3
-  development: halted
-  originals:
-  - 'The Elder Scrolls III: Morrowind'
-  repo: https://github.com/TES3MP/openmw-tes3mp
-  status: playable
-  type: remake
-  multiplayer:
-  - Online
-  url: http://tes3mp.com/
+  info: TES3MP is a project adding multiplayer functionality to OpenMW
+  updated: '2022-02-07'
+  images:
+  - 'https://i2.wp.com/openmw.org/wp-content/uploads/2017/07/hA3oZhX.png'
   video:
     youtube: aZZ0piRvI58
-  info: TES3MP is a project adding multiplayer functionality to OpenMW
-  updated: 2020-10-26
 
 - name: tetris
   images:

--- a/games/t.yaml
+++ b/games/t.yaml
@@ -145,7 +145,7 @@
   type: remake
   updated: 2015-06-18
 
-  name: TES3MP
+- name: TES3MP
   originals:
   - 'The Elder Scrolls III: Morrowind'
   type: remake


### PR DESCRIPTION
Changed back to active, added LAN as an option and defined content as "swappable" (as it can technically use OpenMW's Example Suite instead of Morrowind)