### PR TITLE
X-COM updates

### DIFF
--- a/games/o.yaml
+++ b/games/o.yaml
@@ -638,7 +638,6 @@
   - 'X-COM: UFO Defense'
   - 'X-COM: Terror from the Deep'
   - 'X-COM: Apocalypse'
-  - 'UFO: Enemy Unknown'
   content: commercial
   framework:
   - SDL2
@@ -2279,7 +2278,6 @@
   originals:
   - 'X-COM: UFO Defense'
   - 'X-COM: Terror from the Deep'
-  - 'UFO: Enemy Unknown'
   repo: https://github.com/OpenXcom/OpenXcom
   status: playable
   type: remake

--- a/games/o.yaml
+++ b/games/o.yaml
@@ -635,16 +635,16 @@
   development: active
   status: semi-playable
   originals:
-  - 'X-COM: UFO Defense'
-  - 'X-COM: Terror from the Deep'
   - 'X-COM: Apocalypse'
   content: commercial
   framework:
   - SDL2
   repo: https://github.com/OpenApoc/OpenApoc
   type: remake
-  updated: 2019-07-24
+  updated: 2022-05-03
   url: http://openapoc.org/
+  images:
+  - https://i.imgur.com/CFS3nBK.png
   video:
     youtube: qMy4dYksZVg
 
@@ -2265,15 +2265,16 @@
 
 - name: OpenXcom
   images:
-  - http://openxcom.org/wp-content/gallery/v1-0/00_mainmenu.png
-  - http://openxcom.org/wp-content/gallery/v1-0/01_globe.png
-  - http://openxcom.org/wp-content/gallery/v1-0/04_inventory.png
-  - http://openxcom.org/wp-content/gallery/v1-0/07_pathpreview.png
+  - https://web.archive.org/web/20211231021730if_/https://openxcom.org/wp-content/gallery/v1-0/00_mainmenu.png
+  - https://web.archive.org/web/20211231023450if_/https://openxcom.org/wp-content/gallery/v1-0/01_globe.png
+  - https://web.archive.org/web/20211231021349if_/https://openxcom.org/wp-content/gallery/v1-0/04_inventory.png
+  - https://web.archive.org/web/20211231024034if_/https://openxcom.org/wp-content/gallery/v1-0/07_pathpreview.png
   info: EU and TftD fully playable, feature complete, now development focus on bug fix
   lang:
   - C++
   license:
   - GPL3
+  content: commercial
   development: active
   originals:
   - 'X-COM: UFO Defense'
@@ -2282,7 +2283,9 @@
   status: playable
   type: remake
   url: https://openxcom.org/
-  updated: 2020-04-09
+  video:
+    youtube: oxlRQGnGaDo
+  updated: 2022-05-03
 
 - name: OpenXRay
   originals:

--- a/games/p.yaml
+++ b/games/p.yaml
@@ -735,7 +735,6 @@
   - 'X-COM: UFO Defense'
   - 'X-COM: Terror from the Deep'
   - 'X-COM: Apocalypse'
-  - 'UFO: Enemy Unknown'
   status: unplayable
   type: clone
   updated: 2022-04-23

--- a/games/u.yaml
+++ b/games/u.yaml
@@ -99,7 +99,7 @@
   repo: https://sourceforge.net/projects/ufoai/
   type: clone
   url: https://ufoai.org/wiki/News
-  updated: 2020-08-25
+  updated: 2022-05-03
 
 - name: UGH-remake
   lang:

--- a/games/u.yaml
+++ b/games/u.yaml
@@ -70,7 +70,6 @@
   - 'X-COM: UFO Defense'
   - 'X-COM: Terror from the Deep'
   - 'X-COM: Apocalypse'
-  - 'UFO: Enemy Unknown'
   repo: https://sourceforge.net/projects/ufo2000/
   status: playable
   type: remake
@@ -97,7 +96,6 @@
   - 'X-COM: UFO Defense'
   - 'X-COM: Terror from the Deep'
   - 'X-COM: Apocalypse'
-  - 'UFO: Enemy Unknown'
   repo: https://sourceforge.net/projects/ufoai/
   type: clone
   url: https://ufoai.org/wiki/News

--- a/games/x.yaml
+++ b/games/x.yaml
@@ -56,7 +56,6 @@
   - 'X-COM: UFO Defense'
   - 'X-COM: Terror from the Deep'
   - 'X-COM: Apocalypse'
-  - 'UFO: Enemy Unknown'
   repo: svn://svn.code.sf.net/p/xforceffd/code/trunk
   type: clone
   updated: 2015-04-11
@@ -175,7 +174,6 @@
   - 'X-COM: UFO Defense'
   - 'X-COM: Terror from the Deep'
   - 'X-COM: Apocalypse'
-  - 'UFO: Enemy Unknown'
   repo: https://github.com/leethomason/unflobtactical
   status: playable
   type: clone

--- a/games/x.yaml
+++ b/games/x.yaml
@@ -51,7 +51,7 @@
   - Delphi
   license:
   - GPL2
-  development: sporadic
+  development: halted
   originals:
   - 'X-COM: UFO Defense'
   - 'X-COM: Terror from the Deep'

--- a/originals/u.yaml
+++ b/originals/u.yaml
@@ -1,15 +1,3 @@
-- name: 'UFO: Enemy Unknown'
-  external:
-    wikipedia: 'UFO: Enemy Unknown'
-  meta:
-    genre:
-    - Strategy
-    - Real-Time Strategy
-    - Turn-Based Tactics
-    theme:
-    - Horror
-    - Sci-Fi
-
 - name: Ugh!
   external:
     wikipedia: Ugh!


### PR DESCRIPTION
Firstly: remove dupe game UFO: Enemy Unknown (It's just another name for X-COM: UFO Defense). Already added as an alt-name under original X-COM entry.

Then, a few updates to X-COM-related games.