### PR TITLE
Add Fish Fillets NG

### DIFF
--- a/games/f.yaml
+++ b/games/f.yaml
@@ -176,6 +176,29 @@
   url: http://www.newbreedsoftware.com/fop/
   info: A Dandy clone with Gauntlet influences. Choose from 8 classes and roam the maze taking treasure, vanquishing monters, and finding the exit. Use explosives against enemies and keys on locked doors.
 
+- name: Fish Fillets NG
+  originals:
+  - Fish Fillets
+  type: remake
+  repo: 'https://sourceforge.net/projects/fillets/'
+  url: 'http://fillets.sourceforge.net/'
+  development: complete
+  status: playable
+  content: open
+  lang:
+  - C++
+  - Lua
+  framework:
+  - SDL
+  license:
+  - GPL2
+  info: Cross-platform port of the original game sources.
+  updated: 2022-05-05
+  images:
+  - 'https://upload.wikimedia.org/wikipedia/commons/9/91/Fillets-ng-cellar.png'
+  video:
+    youtube: EgJlCen3Sko
+
 - name: Flappy Bird TIC Edition
   originals:
   - Flappy Bird

--- a/originals/f.yaml
+++ b/originals/f.yaml
@@ -132,6 +132,17 @@
   - Commodore 64
   - DOS
 
+- name: Fish Fillets
+  external:
+    wikipedia: Fish Fillets NG
+  meta:
+    genre:
+    - Puzzle
+    theme:
+    - Aquatic
+  platform:
+  - Windows
+
 - name: Five Nights at Freddy's
   names:
   - FNaF


### PR DESCRIPTION
Hello, the game list is missing Fish Fillets NG, an old Czech puzzle game commercially released in 1997 and open-sourced in 2004.