### PR TITLE
add the OpenGOAL project

### DIFF
--- a/games/o.yaml
+++ b/games/o.yaml
@@ -218,6 +218,33 @@
   video:
     youtube: vnUIWB7Mixw
 
+- name: OpenGOAL
+  originals: 
+  - 'Jak and Daxter: The Precursor Legacy'
+  type: remake
+  repo: https://github.com/open-goal/jak-project
+  url: https://opengoal.dev/
+  development: active
+  status: playable
+  content: commercial
+  langs:
+  - C++
+  - GOAL
+  licenses:
+  - ISC
+  info: >-
+    A project that aims to provide a complete PC port for the first Jak and 
+    Daxter game by providing a open implementation of a compiler for Naughty
+    Dog's GOAL language, a decompiler for the compiled game and an asset
+    extraction tool.
+  updated: '2022-08-28'
+  images:
+  - https://opengoal.dev/assets/images/lurker-chilling_2022-02-04-93d12659deb4cd4cdadda716de276725.png
+  - https://opengoal.dev/assets/images/jak-and-daxter-are-stunned_2022-02-04-12bbd4d7353f20638b9f1994ff8cbe24.png
+  - https://opengoal.dev/assets/images/robotboss-appears_2022-02-04-2455f3b01898dd59e806044daa8ee017.png
+  video:
+    youtube: ZO7A22btJc0
+
 - name: Open Greedy
   originals:
   - Pac-Man

--- a/games/o.yaml
+++ b/games/o.yaml
@@ -229,6 +229,7 @@
   content: commercial
   langs:
   - C++
+  - Common Lisp
   licenses:
   - ISC
   info: >-

--- a/games/o.yaml
+++ b/games/o.yaml
@@ -229,7 +229,6 @@
   content: commercial
   langs:
   - C++
-  - GOAL
   licenses:
   - ISC
   info: >-

--- a/originals/j.yaml
+++ b/originals/j.yaml
@@ -30,6 +30,16 @@
     - Sci-Fi
     - Modern Military
 
+- name: 'Jak and Daxter: The Precursor Legacy'
+  external:
+    wikipedia: 'Jak and Daxter: The Precursor Legacy'
+  meta:
+    genres:
+      - Platform
+    themes:
+      - Fantasy
+      - Sci-Fi
+
 - name: Jazz Jackrabbit
   external:
     wikipedia: Jazz Jackrabbit


### PR DESCRIPTION
Since other decompilation-related projects are now included in the list as well (`sm64ex`, `oot`, etc.), I believe OpenGOAL absolutely deserves a spot on this list!