### PR TITLE
add the Ship of Harkinian project

### DIFF
--- a/games/s.yaml
+++ b/games/s.yaml
@@ -429,7 +429,7 @@
   status: playable
   content: commercial
   licenses:
-  - Custom
+  - As-is
   langs:
   - C
   - C++

--- a/games/s.yaml
+++ b/games/s.yaml
@@ -419,6 +419,27 @@
   type: remake
   updated: 2016-04-11
 
+- name: Ship of Harkinian
+  originals:
+  - 'The Legend of Zelda: Ocarina of Time'
+  type: remake
+  repo: https://github.com/HarbourMasters/Shipwright
+  url: https://www.shipofharkinian.com/
+  development: active
+  status: playable
+  content: commercial
+  licenses:
+  - Custom
+  langs:
+  - C
+  - C++
+  info: >-
+    An enhanced an improved PC port of the original Ocarina of Time based 
+    on the reverse-engineering work done by the OOT decompilation project.
+  updated: '2022-08-29'
+  video:
+    youtube: 4ZNIE5xwjsY
+
 - name: Shockolate
   development: active
   frameworks:


### PR DESCRIPTION
The list already references the `OOT` decompilation project, but that doesn't actually provide a working port. `Ship of Harkinian` is a project that actually works to provide that enhanced port, similar to how `sm64-port` and `sm64ex` are related to the original [n64decomp/sm64](https://github.com/n64decomp/sm64) project.

IMPORTANT NOTE: Unfortunately, Harkinian does not provide a clear listing of the license(s) it uses as far as I can tell. I've added the `Custom` license, but I don't know what the best approach is when nothing is clearly stated. Ideally, it should be tagged with some form of 'source-provided' license I think?