### PR TITLE
Apply dark theme instantly

### DIFF
--- a/static/dark-theme.js
+++ b/static/dark-theme.js
@@ -3,12 +3,12 @@ const DARK_THEME_KEY = 'startInDarkTheme';
 
 function setDarkTheme() {
   document.body.classList.add(DARK_THEME_CLASS);
-  document.getElementById('dark-theme-button').innerHTML = "Light Theme";
+  setThemeButtonText("Light Theme");
 }
 
 function setLightTheme() {
   document.body.classList.remove(DARK_THEME_CLASS);
-  document.getElementById('dark-theme-button').innerHTML = "Dark Theme";
+  setThemeButtonText("Dark Theme");
 }
 
 function toggleDarkTheme() {
@@ -21,7 +21,19 @@ function toggleDarkTheme() {
   }
 }
 
-window.addEventListener('load', function() {
+/**
+ * Safely modify theme button text only if it exists
+ * @param {string} text label for button
+ */
+function setThemeButtonText(text) {
+  const button = document.getElementById('dark-theme-button')
+  if (button) {
+    button.innerHTML = text
+  }
+}
+
+// enable dark theme as soon as possible so first paint is already dark mode
+(function () {
   window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
     if (localStorage.getItem(DARK_THEME_KEY) === null) {
       if (event.matches) {
@@ -34,6 +46,11 @@ window.addEventListener('load', function() {
   if (localStorage.getItem(DARK_THEME_KEY) === 'true' || window.matchMedia('(prefers-color-scheme: dark)').matches) {
     setDarkTheme();
   }
+})();
 
+// handle theme button label and listener once DOM fully loaded
+window.addEventListener('DOMContentLoaded', function () {
+  const isDarkTheme = document.body.classList.contains(DARK_THEME_CLASS)
+  setThemeButtonText(isDarkTheme ? "Light Theme" : "Dark Theme")
   document.getElementById('dark-theme-button').addEventListener('click', toggleDarkTheme)
-});
+})


### PR DESCRIPTION
The site currently applies the dark theme as part of an event listener for window `load`. Because of this, the browser will initially paint with the default light theme still active, then follow up a short but noticeable time later switching to the dark theme.
![osgc_current](https://user-images.githubusercontent.com/3322920/188762169-31fce8e4-4f9b-4306-b502-0fb02953a0e2.gif)

This change executes the step to apply the Dark Theme class (if applicable) immediately, since that script is loaded first thing within the `<body>` tag, then follows up with the button label and click handler inside a window `load` event listener.

This has the effect of causing the page to have the dark theme applied before the browser's first paint.
![osgc_instant_dark](https://user-images.githubusercontent.com/3322920/188762991-83a8ba7a-08b1-438e-8073-840102ad4e57.gif)
