### PR TITLE
Added Deathlord Relorded

### DIFF
--- a/games/d.yaml
+++ b/games/d.yaml
@@ -278,7 +278,7 @@
   langs:
   - C++
   frameworks:
-  - DirectXTK12
+  - DirectX
   originals:
   - Deathlord
   status: playable

--- a/games/d.yaml
+++ b/games/d.yaml
@@ -274,7 +274,7 @@
   images:
   - https://img.itch.zone/aW1hZ2UvMTQxNTUxMi84MjQ1MDM1LnBuZw==/original/TciGJK.png
   licenses:
-  - AGPL 3.0
+  - AGPL3
   langs:
   - C++
   frameworks:

--- a/originals/d.yaml
+++ b/originals/d.yaml
@@ -64,6 +64,18 @@
     subgenres:
     - Vehicular Combat
 
+- name: Deathlord
+  external:
+    wikipedia: Deathlord
+  platforms:
+  - Apple II
+  - Commodore 64
+  meta:
+    genres:
+    - RPG
+    themes:
+    - Fantasy
+
 - name: Decision in the Desert
   external:
     wikipedia: Decision in the Desert


### PR DESCRIPTION
I added Deathlord Relorded, free on itch, with source code on github.

A combination of Ultima and Wizardry, Deathlord was first released for the Apple 2 and C64 platforms in 1987. It is notorious for being the most difficult and sadistic RPG ever created, dwarfing even Wizardry 4. In this reworking of the game, most of the frustrating aspects have been smoothed out, the game now plays in 1920x1080 resolution with a massive increase in map visibility, much nicer visuals, etc..

Except for the removal of permadeath, the difficulty remains. The dungeon puzzles are still the same, and if you're able to get through the 16th level of dungeon Telegrond you can consider yourself a true master of RPGs.

The original code still runs completely untouched, so you are guaranteed to get the exact same behavior by monsters and other NPCs as the original game. You can in fact toggle the original interface from 1987 by pressing `F11` at any time.

REQUIREMENTS: Windows 10, minimum resolution 1920x1080