### PR TITLE
WarCraft 2000: update the repository address

### DIFF
--- a/games/w.yaml
+++ b/games/w.yaml
@@ -89,7 +89,7 @@
   originals:
   - 'Warcraft 2000'
   type: remake
-  repo: 'https://github.com/agend/warcraft-2000-nuclear-epidemic'
+  repo: 'https://github.com/ForNeVeR/warcraft-2000-nuclear-epidemic'
   development: halted
   status: playable
   content: commercial


### PR DESCRIPTION
The original repository holder has decided to delete it after a (very gentle) question on code licensing from a GitHub user.

I'm putting the repo back online under my account (with additional README to answer the licensing questions people may have).