### PR TITLE
Change OpenMC2's status to Halted, as the project is abandoned

### DIFF
--- a/games/o.yaml
+++ b/games/o.yaml
@@ -1764,7 +1764,7 @@
   updated: 2019-09-13
 
 - name: OpenMC2
-  development: sporadic
+  development: halted
   langs:
   - C++
   licenses:


### PR DESCRIPTION
After officially pausing development in 2021 (#1408), I'm officially abandoning the project as it exists. As I said in my [abandonment notice](https://github.com/OpenMC2/OpenMC2#this-project-is-now-abandoned), I may return to re-implementing the original game, but if I do, I will be doing it as a new project.

I remembered there being an 'abandoned' status on the website, but either I misremembered or it was removed at some point, as I couldn't find it. Instead, I opted to just label the project as halted. If there's a better way to indicate the project's abandoned status (or if you'd rather I just remove the game entirely), let me know, and I'll update the PR.