### PR TITLE
Fix light theme preference is ignored

### DIFF
--- a/static/dark-theme.js
+++ b/static/dark-theme.js
@@ -1,6 +1,6 @@
 const DARK_THEME_CLASS = 'dark-theme';
 const LIGHT_THEME_CLASS = 'light-theme';
-const DARK_THEME_KEY = 'startInDarkTheme';
+const THEME_KEY = 'theme';
 
 function setDarkTheme() {
   document.body.classList.remove(LIGHT_THEME_CLASS);
@@ -15,17 +15,17 @@ function setLightTheme() {
 function toggleDarkTheme() {
   if (document.body.classList.contains(DARK_THEME_CLASS)) {
     setLightTheme();
-    localStorage.setItem(DARK_THEME_KEY, 'false')
+    localStorage.setItem(THEME_KEY, 'light')
   } else {
     setDarkTheme();
-    localStorage.setItem(DARK_THEME_KEY, 'true')
+    localStorage.setItem(THEME_KEY, 'dark')
   }
 }
 
 // enable dark theme as soon as possible so first paint is already dark mode
 (function () {
   window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
-    if (localStorage.getItem(DARK_THEME_KEY) === null) {
+    if (localStorage.getItem(THEME_KEY) === null) {
       if (event.matches) {
         setDarkTheme();
       } else {
@@ -33,8 +33,15 @@ function toggleDarkTheme() {
       }
     }
   });
-  if (localStorage.getItem(DARK_THEME_KEY) === 'true' || window.matchMedia('(prefers-color-scheme: dark)').matches) {
-    setDarkTheme();
+
+  if (localStorage.getItem(THEME_KEY) === 'dark') {
+      setDarkTheme();
+  } else if (localStorage.getItem(THEME_KEY) === 'light') {
+      setLightTheme();
+  } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setDarkTheme();
+  } else {
+      setLightTheme();
   }
 })();
 

--- a/static/main.css
+++ b/static/main.css
@@ -240,7 +240,7 @@ dd + dt { margin-top: 1em; }
 .dark-theme .tag.cc-by-nc-sa { background-color: #af8100; }
 .dark-theme .tag.cc-by-nc:hover,
 .dark-theme .tag.cc-by-nc-nd:hover,
-.dark-theme .tag.cc-by-nc-sa:hover { background-color: #f6100; }
+.dark-theme .tag.cc-by-nc-sa:hover { background-color: #8f6100; }
 .dark-theme .tag.as-is,
 .dark-theme .tag.custom { background-color: #dc3545; }
 .dark-theme .tag.as-is:hover,


### PR DESCRIPTION
## The problem cause
When the user clicks the "light mode" button, it sets "startInDarkTheme" to "false" in localStorage, but the init code doesn't test for "false" to toggle the light mode. This becomes apparent when "prefers-color-scheme" is "dark" and the website goes into dark mode instead.

## The fix
I check for _both_ the "dark" and "light" theme preferences in the localStorage first. If those aren't found, I set the theme based on the "prefers-color-scheme" media feature.

I wrote playwright [spec file](https://gist.github.com/alexpalade/ec6a86e6d49a232166194a5345fd3415) (tests at the bottom) to test multiple use cases. I also made [this state chart](https://github.com/opengaming/osgameclones/assets/1126946/dde9e6a5-acc6-4d91-a859-c4542f6f42f0) to clarify the problem.

An observation: the init code should always call either `setDarkTheme` or `setLightTheme` once to hide one of the mode toggle button icons. If none is called, both the moon and sun icons appear.

## Theme key renamed to "theme"

I renamed the localStorage theme key from "startInDarkTheme" (=true/false) to "theme" (=dark/light). I think it's more accurate to store the light theme preference as "theme=light" than "startInDarkTheme=false" which is misleading (and possibly the cause for this bug). It also allows to add an "auto" value (and a drop-down menu) in the future. If you dislike this change, I can revert it.

## Unrelated CSS color fix

I also snuck in a minor CSS typo fix (#**8**f6100) that was generating an error in the browser console. 🥷 I figured out the correct color from the surrounding context.

Closes #1833 