### PR TITLE
Add Populous, Populous II, and open source projects related to the series

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -24,6 +24,7 @@ const knownFrameworks = [
   'BackBone.js',
   'Box2D',
   'Bullet3',
+  'ClanLib',
   'CreateJS',
   'Cocos2d',
   'Construct',
@@ -40,6 +41,7 @@ const knownFrameworks = [
   'Flash',
   'FMOD',
   'GameMaker Studio',
+  'GLUT',
   'Godot',
   'Graphics32',
   'GTK',
@@ -48,6 +50,7 @@ const knownFrameworks = [
   'Irrlicht',
   'JavaFX',
   'JMonkeyEngine',
+  'JOGL',
   'jQuery',
   'Kylix',
   'Laravel',
@@ -123,6 +126,8 @@ const frameworkLangs = {
   'Allegro': ['C++', 'C'],
   'pygame': ['Python'],
   'OGRE': ['C++'],
+  'JOGL': ['Java'],
+  'LWJGL': ['Java'],
 }
 
 // -----------

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -48,6 +48,7 @@ const knownFrameworks = [
   'GTK',
   'Impact',
   'Inform',
+  'Ionic',
   'Irrlicht',
   'JavaFX',
   'JMonkeyEngine',

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -32,6 +32,7 @@ const knownFrameworks = [
   'Crystal Space',
   'Cube 2 Engine',
   'Daemon Engine',
+  'DarkBASIC',
   'DirectX',
   'DIV Games Studio',
   'Duality',

--- a/games/f.yaml
+++ b/games/f.yaml
@@ -947,6 +947,27 @@
   video:
     youtube: 2atHnYAFQgU
 
+- name: FreePop
+  originals:
+  - 'Populous II: Trials of the Olympian Gods'
+  - Populous
+  type: clone
+  repo: 'https://sourceforge.net/projects/freepop/'
+  url: 'https://freepop.sourceforge.net/'
+  development: halted
+  status: semi-playable
+  content: open
+  langs:
+  - C++
+  frameworks:
+  - ClanLib
+  licenses:
+  - GPL2
+  updated: '2023-12-12'
+  images:
+  - 'https://freepop.sourceforge.net/screenshots/freepop-0.6.0-shot1.jpeg'
+  - 'https://freepop.sourceforge.net/screenshots/freepop-0.6.0-shot2.jpeg'
+
 - name: FreePrince
   langs:
   - C

--- a/games/j.yaml
+++ b/games/j.yaml
@@ -58,6 +58,29 @@
   url: https://bytonic.de/html/jake2.html
   info: Java port of the Quake2 game engine
 
+- name: JavaPop
+  originals:
+  - Populous
+  - 'Populous II: Trials of the Olympian Gods'
+  type: clone
+  repo: 'https://code.google.com/archive/p/javapop/'
+  url: 'https://javaglgames.blogspot.com/'
+  development: halted
+  status: semi-playable
+  content: free
+  langs:
+  - Java
+  frameworks:
+  - OpenGL
+  - JOGL
+  licenses:
+  - GPL2
+  info: 'Unofficial mirror: https://github.com/TambourineReindeer/javapop'
+  updated: '2023-12-12'
+  images:
+  - >-
+    https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgdySZ4srVoejSFrBXsJqQXHC-AJimeesIBo1dNAqva2h63EwvvwEKor9JShjNa2sAh50P5upd_wDBmkQo3fJMCaQPiuh09ucjbHyt0ALzks8rDl_DDR3bmIpASrMXOKHY_6CL7XyMbcfKT/s1600-h/JavaPop+Screen+20090123.png
+
 - name: javascript-E.T.
   langs:
   - JavaScript

--- a/games/k.yaml
+++ b/games/k.yaml
@@ -234,6 +234,22 @@
   updated: 2022-07-13
   url: https://www.knightsgame.org.uk/
 
+- name: Krampus Populous Editor
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/NightTerror1721/KrampusPopEditor'
+  development: halted
+  content: swappable
+  langs:
+  - Java
+  frameworks:
+  - Swing
+  licenses:
+  - Custom
+  info: No licence specified
+  updated: '2023-12-12'
+
 - name: KRaptor
   originals:
   - 'Raptor: Call of the Shadows'

--- a/games/o.yaml
+++ b/games/o.yaml
@@ -54,6 +54,23 @@
   - https://odamex.net/w/images/thumb/0/01/Odamex-r166-linuxppc.png/640px-Odamex-r166-linuxppc.png
   - https://odamex.net/w/images/thumb/7/74/Odamex-r166-osxppc.png/640px-Odamex-r166-osxppc.png
 
+- name: oetting
+  originals:
+  - Populous
+  - Mega-Lo-Mania
+  type: similar
+  repo: 'https://sourceforge.net/projects/oetting/'
+  development: halted
+  status: semi-playable
+  content: open
+  langs:
+  - C++
+  frameworks:
+  - GLUT
+  licenses:
+  - GPL2
+  updated: '2023-12-12'
+
 - name: Ogrian Carpet
   originals:
   - Magic Carpet

--- a/games/p.yaml
+++ b/games/p.yaml
@@ -499,19 +499,6 @@
   - 'https://raw.githubusercontent.com/pokemium/PokeTraveler/master/docs/demo3.png'
   - 'https://raw.githubusercontent.com/pokemium/PokeTraveler/master/docs/demo4.png'
 
-- name: poplib
-  originals:
-  - 'Populous: The Beginning'
-  type: tool
-  repo: 'https://sourceforge.net/projects/pop3lib/'
-  development: halted
-  content: swappable
-  langs:
-  - C++
-  licenses:
-  - GPL3
-  updated: '2023-12-12'
-
 - name: Pop3-Scripts
   originals:
   - 'Populous: The Beginning'
@@ -524,6 +511,47 @@
   - Custom
   info: No licence specified
   updated: '2023-12-13'
+
+- name: pop3dobj
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/OpenPop/pop3dobj'
+  development: halted
+  content: commercial
+  langs:
+  - C++
+  licenses:
+  - Custom
+  info: 'Public domain; see https://github.com/OpenPop/notes#alacn'
+  updated: '2023-12-13'
+
+- name: popdisp
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/OpenPop/popdisp'
+  development: halted
+  content: swappable
+  langs:
+  - Component Pascal
+  licenses:
+  - Custom
+  info: 'Public domain; see https://github.com/OpenPop/notes#alacn'
+  updated: '2023-12-13'
+
+- name: poplib
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://sourceforge.net/projects/pop3lib/'
+  development: halted
+  content: swappable
+  langs:
+  - C++
+  licenses:
+  - GPL3
+  updated: '2023-12-12'
 
 - name: popss
   originals:
@@ -580,6 +608,20 @@
   - 'https://www.b3dgs.com/v7/chronology/populous_the_aftermath/14.jpg'
   - 'https://www.b3dgs.com/v7/chronology/populous_the_aftermath/15.jpg'
 
+- name: Populous Background Extractor
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/OpenPop/PopBgExtract'
+  development: halted
+  content: swappable
+  langs:
+  - Component Pascal
+  licenses:
+  - Custom
+  info: 'Public domain; see https://github.com/OpenPop/notes#alacn'
+  updated: '2023-12-13'
+
 - name: Populous Colour Changer
   originals:
   - 'Populous: The Beginning'
@@ -592,6 +634,20 @@
   licenses:
   - Custom
   info: No licence specified
+  updated: '2023-12-13'
+
+- name: Populous HDR Editor
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/OpenPop/PopHdrEdt'
+  development: halted
+  content: swappable
+  langs:
+  - Component Pascal
+  licenses:
+  - Custom
+  info: 'Public domain; see https://github.com/OpenPop/notes#alacn'
   updated: '2023-12-13'
 
 - name: Populous Map Viewer
@@ -670,6 +726,20 @@
   info: No licence specified
   updated: '2023-12-13'
 
+- name: Pop Sprite Extractor
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/OpenPop/popspr'
+  development: halted
+  content: swappable
+  langs:
+  - Component Pascal
+  licenses:
+  - Custom
+  info: 'Public domain; see https://github.com/OpenPop/notes#alacn'
+  updated: '2023-12-13'
+
 - name: Populous Symmetry Tool
   originals:
   - 'Populous: The Beginning'
@@ -699,6 +769,20 @@
   - MIT
   updated: '2023-12-13'
 
+- name: Populous The Beginning Fix
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/OpenPop/popfix'
+  development: halted
+  content: commercial
+  langs:
+  - Component Pascal
+  licenses:
+  - Custom
+  info: 'Public domain; see https://github.com/OpenPop/notes#alacn'
+  updated: '2023-12-13'
+
 - name: Populous World Editor
   originals:
   - 'Populous: The Beginning'
@@ -712,7 +796,7 @@
   - DirectX
   licenses:
   - Custom
-  info: No licence specified
+  info: 'No licence specified; older version (https://github.com/OpenPop/PopWorldEditor) is in public domain according to https://github.com/OpenPop/notes#alacn'
   updated: '2023-12-13'
 
 - name: Prepare Carefully

--- a/games/p.yaml
+++ b/games/p.yaml
@@ -610,6 +610,38 @@
   info: Unofficial mirror
   updated: '2023-12-13'
 
+- name: Populous Matchmaker Web App
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/PopRe/popmm-webapp'
+  url: 'https://play.google.com/store/apps/details?id=net.popre.mm'
+  development: halted
+  langs:
+  - TypeScript
+  frameworks:
+  - Ionic
+  licenses:
+  - Custom
+  info: >-
+    No licence specified; has companion bot for hosting games
+    (https://github.com/PopRe/HostBot) and an older version
+    (https://github.com/PopRe/PopMM-Mobile), both under the MIT licence
+  updated: '2023-12-13'
+  images:
+  - >-
+    https://play-lh.googleusercontent.com/nvA6W6d7wwTHhCRD8QbBARhiJEen0WZnPstqd7KSo8kqk0IQEoeH9NTEZkOB4z_0oR-c=w2560-h1440
+  - >-
+    https://play-lh.googleusercontent.com/ArbQBhd6m5S68vUUm06d6VfC8LRsQBhiXvasMJL5YJk_qd0yihnGrWKT9KhvBtf4Q6A=w2560-h1440
+  - >-
+    https://play-lh.googleusercontent.com/CDUeQ_Ku-ekCosyRC3x4p37e7PBSGdcGAwAz6GlFRpYkKPQXdPnGGk8cNr1BOatZkr0=w2560-h1440
+  - >-
+    https://play-lh.googleusercontent.com/MtCkebaTLWxLVf2cpBYcxoZec62h7N2REQEbxCC1ts-KongXCGZlidyhcPeQLb-0C-4=w2560-h1440
+  - >-
+    https://play-lh.googleusercontent.com/U2oNWAtxWVKslzn_MRwH18MYvOO0QB4gexPZAvRN5lImWzAYaRCgCvBwSRQnOTN_Am6v=w2560-h1440
+  - >-
+    https://play-lh.googleusercontent.com/Jy3Jw29X-Ns7Vmgs5U6TZ2Los6CsMHGj0Zdj1HnPIk2ECYr0e6twVeUadMvhTB-CZA=w2560-h1440
+
 - name: Populous Palette Editor
   originals:
   - 'Populous: The Beginning'
@@ -665,6 +697,22 @@
   - .NET
   licenses:
   - MIT
+  updated: '2023-12-13'
+
+- name: Populous World Editor
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/PopRe/Pop-World-Editor'
+  development: halted
+  content: swappable
+  langs:
+  - C++
+  frameworks:
+  - DirectX
+  licenses:
+  - Custom
+  info: No licence specified
   updated: '2023-12-13'
 
 - name: Prepare Carefully

--- a/games/p.yaml
+++ b/games/p.yaml
@@ -553,6 +553,42 @@
   - GPL3
   updated: '2023-12-12'
 
+- name: PopSoundEditor
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/Toksisitee/PopSoundEditor'
+  url: 'https://toksisitee.github.io/blog/pop-sound-editor'
+  development: halted
+  content: swappable
+  langs:
+  - C++
+  frameworks:
+  - Qt
+  licenses:
+  - GPL3
+  updated: '2023-12-13'
+  images:
+  - >-
+    https://toksisitee.github.io/assets/images/pop-sound-editor-309db5fc13f4a6967dd4dd993c074bb6.png
+
+- name: PopSpriteEditor
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/Toksisitee/PopSpriteEditor'
+  url: 'https://toksisitee.github.io/blog/pop-sprite-editor'
+  development: halted
+  content: swappable
+  langs:
+  - C++
+  licenses:
+  - GPL3
+  updated: '2023-12-13'
+  images:
+  - >-
+    https://toksisitee.github.io/assets/images/pop-sprite-editor-8b57061a4105962dc4a5470d17867bc6.png
+
 - name: popss
   originals:
   - 'Populous: The Beginning'
@@ -569,6 +605,28 @@
   - Custom
   info: No licence specified
   updated: '2023-12-12'
+
+- name: PopWorldEditor
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/Toksisitee/ALACNPopWorldEditor'
+  url: 'https://toksisitee.github.io/blog/pop-world-editor'
+  development: halted
+  content: swappable
+  langs:
+  - C++
+  frameworks:
+  - DirectX
+  licenses:
+  - Custom
+  info: >-
+    Based on Alacn's editor, so presumably also public domain?
+    https://github.com/OpenPop/notes#alacn
+  updated: '2023-12-13'
+  images:
+  - >-
+    https://toksisitee.github.io/assets/images/pop-world-editor-8bb906eb25290f5479bc9d82eab013f1.gif
 
 - name: Populous - The Aftermath
   originals:

--- a/games/p.yaml
+++ b/games/p.yaml
@@ -547,7 +547,8 @@
   originals:
   - 'Populous: The Beginning'
   type: tool
-  repo: 'https://code.google.com/archive/p/populousmapviewer/'
+  repo: 'https://github.com/TambourineReindeer/populousmapviewer'
+  url: 'https://code.google.com/archive/p/populousmapviewer/'
   development: halted
   langs:
   - C++
@@ -555,8 +556,8 @@
   - OpenGL
   licenses:
   - MIT
-  info: 'Unofficial mirror: https://github.com/TambourineReindeer/populousmapviewer'
-  updated: '2023-12-12'
+  info: Unofficial mirror
+  updated: '2023-12-13'
 
 - name: Populous Palette Editor
   originals:
@@ -725,15 +726,16 @@
   originals:
   - Populous
   type: clone
-  repo: 'https://code.google.com/archive/p/propop/'
+  repo: 'https://github.com/TambourineReindeer/propop'
+  url: 'https://code.google.com/archive/p/propop/'
   development: halted
   status: unplayable
   langs:
   - C++
   licenses:
   - MIT
-  info: 'Unofficial mirror: https://github.com/TambourineReindeer/propop'
-  updated: '2023-12-12'
+  info: Unofficial mirror
+  updated: '2023-12-13'
 
 - name: Pokémon Polished Crystal
   originals:

--- a/games/p.yaml
+++ b/games/p.yaml
@@ -512,6 +512,19 @@
   - GPL3
   updated: '2023-12-12'
 
+- name: Pop3-Scripts
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/MrKosjaK/Pop3-Scripts'
+  development: halted
+  langs:
+  - Lua
+  licenses:
+  - Custom
+  info: No licence specified
+  updated: '2023-12-13'
+
 - name: popss
   originals:
   - 'Populous: The Beginning'
@@ -528,6 +541,44 @@
   - Custom
   info: No licence specified
   updated: '2023-12-12'
+
+- name: Populous - The Aftermath
+  originals:
+  - 'Populous: The Beginning'
+  type: clone
+  repo: >-
+    https://web.archive.org/web/20110518174920/http://b3dgs.com/v4/projects/populous_the_aftermath/populous_the_aftermath_sources.rar
+  url: >-
+    https://www.popre.net/forum/interesting-find-populous-the-aftermath-source-code-t10123.html
+  development: halted
+  status: semi-playable
+  content: commercial
+  langs:
+  - DarkBASIC
+  frameworks:
+  - DarkBASIC
+  licenses:
+  - Custom
+  info: >-
+    No licence specified, but DarkBASIC itself is now FOSS:
+    https://github.com/TheGameCreators/Dark-Basic-Pro
+  updated: '2023-12-13'
+  images:
+  - 'https://www.b3dgs.com/v7/chronology/populous_the_aftermath/1.jpg'
+  - 'https://www.b3dgs.com/v7/chronology/populous_the_aftermath/2.jpg'
+  - 'https://www.b3dgs.com/v7/chronology/populous_the_aftermath/3.jpg'
+  - 'https://www.b3dgs.com/v7/chronology/populous_the_aftermath/4.jpg'
+  - 'https://www.b3dgs.com/v7/chronology/populous_the_aftermath/5.jpg'
+  - 'https://www.b3dgs.com/v7/chronology/populous_the_aftermath/6.jpg'
+  - 'https://www.b3dgs.com/v7/chronology/populous_the_aftermath/7.jpg'
+  - 'https://www.b3dgs.com/v7/chronology/populous_the_aftermath/8.jpg'
+  - 'https://www.b3dgs.com/v7/chronology/populous_the_aftermath/9.jpg'
+  - 'https://www.b3dgs.com/v7/chronology/populous_the_aftermath/10.jpg'
+  - 'https://www.b3dgs.com/v7/chronology/populous_the_aftermath/11.jpg'
+  - 'https://www.b3dgs.com/v7/chronology/populous_the_aftermath/12.jpg'
+  - 'https://www.b3dgs.com/v7/chronology/populous_the_aftermath/13.jpg'
+  - 'https://www.b3dgs.com/v7/chronology/populous_the_aftermath/14.jpg'
+  - 'https://www.b3dgs.com/v7/chronology/populous_the_aftermath/15.jpg'
 
 - name: Populous Colour Changer
   originals:

--- a/games/p.yaml
+++ b/games/p.yaml
@@ -1,3 +1,16 @@
+- name: P3MEditor
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://sourceforge.net/projects/p3meditor/'
+  development: halted
+  content: swappable
+  langs:
+  - C++
+  licenses:
+  - GPL3
+  updated: '2023-12-12'
+
 - name: Pac Go
   originals:
   - Pac-Man
@@ -486,6 +499,122 @@
   - 'https://raw.githubusercontent.com/pokemium/PokeTraveler/master/docs/demo3.png'
   - 'https://raw.githubusercontent.com/pokemium/PokeTraveler/master/docs/demo4.png'
 
+- name: poplib
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://sourceforge.net/projects/pop3lib/'
+  development: halted
+  content: swappable
+  langs:
+  - C++
+  licenses:
+  - GPL3
+  updated: '2023-12-12'
+
+- name: popss
+  originals:
+  - 'Populous: The Beginning'
+  type: clone
+  repo: 'https://github.com/IntelOrca/popss'
+  development: halted
+  status: semi-playable
+  langs:
+  - C++
+  frameworks:
+  - OpenGL
+  - SDL2
+  licenses:
+  - Custom
+  info: No licence specified
+  updated: '2023-12-12'
+
+- name: Populous Colour Changer
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/IntelOrca/archived-VB6/tree/master/Populous/ColourChanger'
+  development: halted
+  content: swappable
+  langs:
+  - Visual Basic
+  licenses:
+  - Custom
+  info: No licence specified
+  updated: '2023-12-13'
+
+- name: Populous Map Viewer
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://code.google.com/archive/p/populousmapviewer/'
+  development: halted
+  langs:
+  - C++
+  frameworks:
+  - OpenGL
+  licenses:
+  - MIT
+  info: 'Unofficial mirror: https://github.com/TambourineReindeer/populousmapviewer'
+  updated: '2023-12-12'
+
+- name: Populous Palette Editor
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/IntelOrca/archived-VB6/tree/master/Populous/PaletteEditor'
+  development: halted
+  content: swappable
+  langs:
+  - Visual Basic
+  licenses:
+  - Custom
+  info: No licence specified
+  updated: '2023-12-13'
+
+- name: Populous Spell Editor
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/IntelOrca/archived-VB6/tree/master/Populous/SpellEditor'
+  development: halted
+  content: swappable
+  langs:
+  - Visual Basic
+  licenses:
+  - Custom
+  info: No licence specified
+  updated: '2023-12-13'
+
+- name: Populous Symmetry Tool
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/IntelOrca/archived-VB6/tree/master/Populous/SymmetryTool'
+  development: halted
+  content: swappable
+  langs:
+  - Visual Basic
+  licenses:
+  - Custom
+  info: No licence specified
+  updated: '2023-12-13'
+
+- name: Populous Symmetry Tool (poptools.net)
+  originals:
+  - 'Populous: The Beginning'
+  type: tool
+  repo: 'https://github.com/IntelOrca/poptools.net'
+  development: halted
+  content: swappable
+  langs:
+  - Visual Basic .NET
+  frameworks:
+  - .NET
+  licenses:
+  - MIT
+  updated: '2023-12-13'
+
 - name: Prepare Carefully
   originals:
   - RimWorld
@@ -591,6 +720,20 @@
     https://cloud.githubusercontent.com/assets/22880786/19826387/7ad0f0d2-9dd4-11e6-92f3-eb47b395ac63.png
   video:
     youtube: mVzuBIBCL5o
+
+- name: propop
+  originals:
+  - Populous
+  type: clone
+  repo: 'https://code.google.com/archive/p/propop/'
+  development: halted
+  status: unplayable
+  langs:
+  - C++
+  licenses:
+  - MIT
+  info: 'Unofficial mirror: https://github.com/TambourineReindeer/propop'
+  updated: '2023-12-12'
 
 - name: Pokémon Polished Crystal
   originals:

--- a/games/w.yaml
+++ b/games/w.yaml
@@ -60,6 +60,27 @@
   video:
     youtube: n9ALgxcTBU0
 
+- name: War of Faith
+  originals:
+  - 'Populous: The Beginning'
+  - Black & White
+  type: similar
+  repo: 'https://sourceforge.net/projects/waroffaith/'
+  development: halted
+  status: semi-playable
+  content: open
+  langs:
+  - C++
+  frameworks:
+  - SDL
+  - OpenGL
+  licenses:
+  - GPL2
+  updated: '2023-12-12'
+  images:
+  - 'https://a.fsdn.com/con/app/proj/waroffaith/screenshots/200964.jpg'
+  - 'https://a.fsdn.com/con/app/proj/waroffaith/screenshots/202130.jpg'
+
 - name: War Thunder
   originals:
   - War Thunder

--- a/originals/p.yaml
+++ b/originals/p.yaml
@@ -502,9 +502,62 @@
     genres:
     - Arcade
 
+- name: Populous
+  names:
+  - 'Populous: The Promised Lands'
+  - 'Populous: The Final Frontier'
+  external:
+    wikipedia: Populous (video game)
+  platforms:
+  - Acorn 32-bit
+  - Amiga
+  - Atari
+  - Classic Mac OS
+  - DOS
+  - FM Towns
+  - Game Boy
+  - Genesis
+  - Master System
+  - PC-98
+  - SNES
+  - TurboGrafx-16
+  - X68000
+  meta:
+    genres:
+    - Real-Time Strategy
+    - Strategy
+    themes:
+    - Management
+
+- name: 'Populous II: Trials of the Olympian Gods'
+  names:
+  - 'Populous II: The Challenge Games'
+  - 'Two Tribes: Populous II'
+  external:
+    wikipedia: 'Populous II: Trials of the Olympian Gods'
+  platforms:
+  - Amiga
+  - Atari
+  - Classic Mac OS
+  - DOS
+  - FM Towns
+  - Genesis
+  - PC-98
+  - SNES
+  - X68000
+  meta:
+    genres:
+    - Real-Time Strategy
+    - Strategy
+    themes:
+    - Management
+
 - name: 'Populous: The Beginning'
   external:
     wikipedia: 'Populous: The Beginning'
+  platforms:
+  - PlayStation
+  - Windows
   meta:
     genres:
     - Real-Time Strategy

--- a/schema/originals.yaml
+++ b/schema/originals.yaml
@@ -102,6 +102,7 @@ schema;platforms:
     'Web',
     'Wii',
     'Windows',
+    'X68000',
     'Xbox',
     'Xbox 360',
     'Xbox One',


### PR DESCRIPTION
(Copied and pasted from original pull request)

Most were from https://github.com/OpenPop/notes but some were added from https://toksisitee.github.io/blog/Projects, https://github.com/PopRe, or incidental searching. Unfortunately, most projects haven't been touched for a long time, but maybe having them in the list can help anyone who might be interested in continuing them or creating their own.

I also had to add a few new frameworks to [dangerfile.js](https://github.com/Razzaline/osgameclones/blob/pr-populous/dangerfile.js) and add X68000 to platforms in [originals.yml](https://github.com/Razzaline/osgameclones/blob/pr-populous/schema/originals.yaml).