### PR TITLE
Using the official name for Sonic 3 AIR

### DIFF
--- a/games/s.yaml
+++ b/games/s.yaml
@@ -1600,7 +1600,7 @@
   video:
     youtube: gzIfRW91IxE
 
-- name: 'Sonic 3: Angel Island Revistied'
+- name: 'Sonic 3 A.I.R - Angel Island Revisited'
   originals:
   - Sonic the Hedgehog
   type: remake


### PR DESCRIPTION
The name as from the front page of the official manual: https://sonic3air.org/Manual.pdf

(Also fixed a typo in "Revisited".)