### PR TITLE
Added Gikopoi reimplementations

### DIFF
--- a/games/g.yaml
+++ b/games/g.yaml
@@ -175,6 +175,37 @@
   video:
     youtube: lTtT9p9DVL8
 
+- name: Gikopoipoi
+  originals:
+  - Gikopoi
+  type: remake
+  repo: 'https://github.com/iccanobif/gikopoi2/'
+  url: 'https://gikopoipoi.net'
+  development: active
+  status: playable
+  langs:
+  - TypeScript
+  licenses:
+  - Unlicense
+  updated: '2024-12-01'
+  video:
+    youtube: TOMaQmWecKw
+
+- name: Gikopoi.com
+  originals:
+  - Gikopoi
+  type: remake
+  repo: 'https://github.com/153/gikopoi3'
+  url: 'https://gikopoi.com/'
+  development: active
+  status: playable
+  langs:
+  - TypeScript
+  licenses:
+  - Custom
+  info: Fork of Gikopoipoi with some extra stuff.
+  updated: '2024-12-01'
+
 - name: Gish
   originals:
   - Gish

--- a/games/g.yaml
+++ b/games/g.yaml
@@ -187,7 +187,8 @@
   - TypeScript
   licenses:
   - Unlicense
-  updated: '2024-12-01'
+  added: '2024-12-06'
+  updated: '2024-12-06'
   video:
     youtube: TOMaQmWecKw
 
@@ -204,7 +205,8 @@
   licenses:
   - Custom
   info: Fork of Gikopoipoi with some extra stuff.
-  updated: '2024-12-01'
+  added: '2024-12-06'
+  updated: '2024-12-06'
 
 - name: Gish
   originals:

--- a/originals/g.yaml
+++ b/originals/g.yaml
@@ -95,6 +95,15 @@
     themes:
     - Comedy
 
+- name: Gikopoi
+  names:
+  - BARギコっぽいONLINE
+  - Bar Gikopoi Online
+  external:
+    website: 'http://l4cs.jpn.org/gikopoi/'
+  platforms:
+  - Web
+
 - name: Gladiator
   external:
     wikipedia: Gladiator


### PR DESCRIPTION
Gikopoi was a multiplayer, online chatroom with avatars based on Shift_JIS art characters from 2channel ([here](https://namelessrumia.heliohost.org/w/doku.php?id=gikopoi) is most details about it). 

Some clarifications: 

* If the game had to be categorized within a genre, I think the most appropriate would be MMO (since it's basically like a Japanese version of Habbo) but that category is not available and considering it an MMORPG doesn't seem entirely correct to me. 
* Regarding the reimplementations, for the names I based on what appears on their respective websites, but if necessary you could also use the name they have in Github (Gikopoi2 and Gikopoi3).