### PR TITLE
Add OpenOrion2

### DIFF
--- a/games/o.yaml
+++ b/games/o.yaml
@@ -486,6 +486,23 @@
   - https://openmeridian.org/wp-content/uploads/2014/01/battle-arena.png
   - https://openmeridian.org/wp-content/uploads/2014/01/new-lore.png
 
+- name: OpenOrion2
+  originals:
+  - Master of Orion 2
+  type: remake
+  repo: https://github.com/nextghost/openorion2
+  development: active
+  status: unplayable
+  content: commercial
+  langs:
+  - C++
+  frameworks:
+  - SDL2
+  licenses:
+  - GPL2
+  added: 2025-06-25
+  updated: 2025-06-25
+
 - name: Open Panzer
   images:
   - https://user-images.githubusercontent.com/1650801/74080138-50fc4700-4a49-11ea-8fbc-a571b6d4ce3c.png


### PR DESCRIPTION
Hello, I'd like to add another of my game remakes. OpenOrion2 currently works as a partial viewer for saved games from the original Master of Orion 2.