### PR TITLE
Add Avara

### DIFF
--- a/games/a.yaml
+++ b/games/a.yaml
@@ -929,3 +929,20 @@
   images:
   - https://ppb.chymera.eu/fefa2d.png
   - 'https://raw.githubusercontent.com/Keriew/augustus/master/res/vita/bg.png'
+
+- name: Avara
+  originals:
+  - Avara
+  type: official
+  url: 'https://github.com/jmunkki/Avara'
+  development: complete
+  status: playable
+  content: commercial
+  langs:
+  - C
+  - C++
+  licenses:
+  - MIT
+  added: 2025-07-06
+  updated: 2025-07-06
+

--- a/games/a.yaml
+++ b/games/a.yaml
@@ -940,7 +940,6 @@
   content: commercial
   langs:
   - C
-  - C++
   licenses:
   - MIT
   added: 2025-07-06

--- a/originals/a.yaml
+++ b/originals/a.yaml
@@ -573,6 +573,19 @@
     genres:
     - Puzzle
 
+- name: Avara
+  external:
+    website: 'https://www.mobygames.com/game/126476/avara/'
+    wikipedia: Avara
+  platforms:
+  - Classic Mac OS
+  meta:
+    genres:
+    - Shooter
+    themes:
+    - Post-Apocalyptic
+    - Sci-Fi
+
 - name: Awesomenauts
   external:
     wikipedia: Awesomenauts

--- a/originals/a.yaml
+++ b/originals/a.yaml
@@ -581,7 +581,7 @@
   - Classic Mac OS
   meta:
     genres:
-    - Shooter
+    - FPS
     themes:
     - Post-Apocalyptic
     - Sci-Fi


### PR DESCRIPTION
I'm not sure whether to change the url field to [the modern port](https://github.com/avaraline/Avara) or add both versions.