### PR TITLE
Add HashCon - Galcon remake #3518

### DIFF
--- a/games/h.yaml
+++ b/games/h.yaml
@@ -183,6 +183,24 @@
   - >-
     https://raw.githubusercontent.com/ivanperez-keera/haskanoid/refs/heads/develop/screenshots/desktop.png
 
+- name: HashCon
+  originals:
+  - Galcon
+  type: remake
+  repo: https://github.com/BXL909/HASHCON
+  url: https://bxl909.github.io/HASHCON/
+  development: complete
+  status: playable
+  content: open
+  langs:
+  - JavaScript
+  licenses:
+  - Custom
+  added: 2025-10-06
+  updated: 2025-10-06
+  images:
+  - https://github.com/BXL909/HashCon/raw/main/card.png?raw=true
+
 - name: Haskelloids
   originals:
   - Asteroids

--- a/originals/g.yaml
+++ b/originals/g.yaml
@@ -25,6 +25,22 @@
     themes:
     - Sci-Fi
 
+- name: Galcon
+  external:
+    website: https://www.galcon.com/
+    wikipedia: Galcon
+  platforms:
+  - Web
+  - iOS
+  - Android
+  - Windows
+  - OSX
+  meta:
+    genres:
+    - Real-Time Strategy
+    themes:
+    - Sci-Fi
+
 - name: Galaxian
   external:
     wikipedia: Galaxian


### PR DESCRIPTION
## 🎃 Hacktoberfest 2025 Contribution

This PR adds **HashCon**, a JavaScript remake of the classic strategy game **Galcon**, as requested in issue #3518.

### 🎮 Game Added:

**HashCon** - A complete remake of Galcon featuring:
- **Type**: Remake
- **Language**: JavaScript  
- **Status**: Playable and complete
- **Content
