### PR TITLE
Remove Open Valley

### DIFF
--- a/games/o.yaml
+++ b/games/o.yaml
@@ -781,29 +781,6 @@
   - MPL
   updated: '2023-02-11'
 
-- name: Open Valley
-  originals:
-  - Stardew Valley
-  type: similar
-  repo: 'https://gitea.it/rixty/OpenValley'
-  url: 'https://mastodon.gamedev.place/@OpenValley'
-  feed: 'https://mastodon.gamedev.place/@OpenValley.rss'
-  development: halted
-  status: semi-playable
-  content: open
-  langs:
-  - C++
-  frameworks:
-  - SDL2
-  licenses:
-  - CC-BY-NC-SA
-  info: Made in Flare engine
-  added: '2021-05-29'
-  updated: 2024-06-23
-  images:
-  - >-
-    https://cdn.masto.host/mastodongamedevplace/media_attachments/files/106/239/851/573/039/205/original/ccf384e1d27196dd.png
-
 - name: OpenVic
   originals:
   - Victoria II


### PR DESCRIPTION
The project is dead and removed by the authors themselves.

- https://gitea.it/rixty/OpenValley
	404 Not Found
- https://mastodon.gamedev.place/@OpenValley
	The page you were looking for doesn't exist here anymore.
- There is no fork repo on [gitea.it](https://gitea.it/explore/repos?only_show_relevant=false&q=OpenValley&sort=recentupdate) or [github](https://github.com/search?q=OpenValley&type=repositories)
