### PR TITLE
Add UZDoom

### DIFF
--- a/games/u.yaml
+++ b/games/u.yaml
@@ -11,12 +11,11 @@
   - Doom
   - Heretic
   - Hexen
-  status: unplayable
+  status: playable
   repo: https://github.com/UZDoom/UZDoom
   type: remake
   added: 2025-10-19
   updated: 2025-10-19
-  url: https://zdoom.org/index
   info: UZDoom is a modder-friendly OpenGL and Vulkan source port based on the DOOM engine
 
 - name: UA_source


### PR DESCRIPTION
[After the drama with the GZDoom main developer](https://github.com/ZDoom/gzdoom/issues/3395), many of the GZDoom developers forked the project and started UZDoom. Yes, another Doom source port into the menu but it seems it gonna be more constant than GZDoom. 

Time will tell