### PR TITLE
hypersomnia.xyz -> hypersomnia.io

### DIFF
--- a/games/h.yaml
+++ b/games/h.yaml
@@ -1051,7 +1051,7 @@
   - Hotline Miami
   type: similar
   repo: 'https://github.com/TeamHypersomnia/Hypersomnia'
-  url: 'https://hypersomnia.xyz'
+  url: 'https://hypersomnia.io'
   development: sporadic
   status: playable
   multiplayer:


### PR DESCRIPTION
We are migrating all services from https://hypersomnia.xyz to https://hypersomnia.io.