### PR TITLE
Add Atari Source Code from Gray Chang

### DIFF
--- a/games/a.yaml
+++ b/games/a.yaml
@@ -2182,6 +2182,26 @@
   images:
   - https://raw.githubusercontent.com/TheBeachLab/asteroids/master/img/screenshot.png
 
+- name: Atari Source Code from Gray Chang
+  originals:
+  - Dog Daze
+  - Dog Daze Deluxe
+  - Bumpomov's Dogs
+  - Claim Jumper
+  type: official
+  repo: 'https://archive.org/details/GrayChangAtariSourceCode'
+  url: >-
+    https://forums.atariage.com/topic/231111-source-code-and-printed-matter-from-gray-chang/
+  development: complete
+  status: playable
+  content: free
+  langs:
+  - Assembly
+  licenses:
+  - As-is
+  added: 2025-12-28
+  updated: 2025-12-28
+
 - name: Atari8bit_StarRaiders
   info: reverse engineering project
   langs:

--- a/originals/b.yaml
+++ b/originals/b.yaml
@@ -1066,6 +1066,15 @@
     genres:
     - Arcade
 
+- name: Bumpomov's Dogs
+  external:
+    website: 'https://ataridogdaze.com/bumpomov/bumpomov.shtml'
+  platforms:
+  - Atari
+  meta:
+    genres:
+    - Action
+
 - name: BurgerTime
   external:
     wikipedia: BurgerTime

--- a/originals/c.yaml
+++ b/originals/c.yaml
@@ -490,8 +490,10 @@
     - 4X
 
 - name: Claim Jumper
+  names:
+  - Gold Rush
   external:
-    website: 'https://www.mobygames.com/game/29303/claim-jumper/'
+    website: 'https://ataridogdaze.com/claimjumper/claimjumper.shtml'
     wikipedia: Claim Jumper (video game)
   platforms:
   - Atari

--- a/originals/d.yaml
+++ b/originals/d.yaml
@@ -620,6 +620,24 @@
     genres:
     - Arcade
 
+- name: Dog Daze
+  external:
+    website: 'https://ataridogdaze.com/dog_daze_old/dog_daze_old.shtml'
+  platforms:
+  - Atari
+  meta:
+    genres:
+    - Action
+
+- name: Dog Daze Deluxe
+  external:
+    website: 'https://ataridogdaze.com/dog_daze_deluxe/dog_daze_deluxe.shtml'
+  platforms:
+  - Atari
+  meta:
+    genres:
+    - Action
+
 - name: Dogs of War
   external:
     wikipedia: Dogs of War (1989 video game)


### PR DESCRIPTION
Tip: The source code in the ATR image is available for viewing through the online tool [ATR Image Explorer.](https://rossumur.github.io/esp_8_bit/atr_image_explorer.htm)