### PR TITLE
Add DM48

### DIFF
--- a/games/d.yaml
+++ b/games/d.yaml
@@ -1347,6 +1347,31 @@
   added: 2025-12-05
   updated: 2025-12-05
 
+- name: DM48
+  originals:
+  - Dungeon Master
+  type: clone
+  url: 'https://gourichon.org/stephane/hp48/dm48/index.html'
+  development: halted
+  status: playable
+  langs:
+  - Assembly
+  licenses:
+  - GPL2
+  added: 2026-02-09
+  updated: 2026-02-09
+  images:
+  - 'https://gourichon.org/stephane/hp48/dm48/dmpreview.gif'
+  - 'https://gourichon.org/stephane/hp48/dm48/dmanimated.gif'
+  - 'https://gourichon.org/stephane/hp48/dm48/Dmroom.gif'
+  - 'https://gourichon.org/stephane/hp48/dm48/ESCAL00.gif'
+  - 'https://gourichon.org/stephane/hp48/dm48/Dmobj.gif'
+  - 'https://gourichon.org/stephane/hp48/dm48/Dmtelepb.gif'
+  - 'https://gourichon.org/stephane/hp48/dm48/Dmtelepi.gif'
+  - 'https://gourichon.org/stephane/hp48/dm48/objetdecor.gif'
+  - 'https://gourichon.org/stephane/hp48/dm48/Dmgr01.gif'
+  - 'https://gourichon.org/stephane/hp48/dm48/FANTOME1.gif'
+
 - name: DNF-reimposition
   originals:
   - Duke Nukem Forever


### PR DESCRIPTION
Tip: Run `hpdir -e HP_directory_object.dir` to extract the source code (requires [HPDir](https://www.hpcalc.org/details/4766)).