### PR TITLE
Update Pizza Legacy entry

### DIFF
--- a/games/p.yaml
+++ b/games/p.yaml
@@ -1780,17 +1780,17 @@
   development: active
   originals:
   - Pizza Tycoon
-  status: semi-playable
+  status: playable
   repo: https://codeberg.org/cowomaly/pizzalegacy/
   type: remake
   multiplayer:
   - Hotseat
   content: commercial
   added: 2026-03-07
-  updated: 2026-03-07
+  updated: 2026-05-26
   url: https://pizzalegacy.nl
   video:
-    youtube: DBb6057QBVg
+    youtube: EpmJT6RckJk
 
 - name: Planet Blupi
   originals:


### PR DESCRIPTION
A new release (v0.1.0) means the game is now properly playable. Also update to the Youtube link for a newer video.